### PR TITLE
New Option for Resolvers: Skip schema emit

### DIFF
--- a/src/decorators/types.ts
+++ b/src/decorators/types.ts
@@ -58,6 +58,9 @@ export interface SchemaNameOptions {
 export interface AbstractClassOptions {
   isAbstract?: boolean;
 }
+export interface SkipSchemaEmitOptions {
+  skipSchemaEmit?: boolean;
+}
 export interface ResolveTypeOptions<TSource = any, TContext = any> {
   resolveType?: TypeResolver<TSource, TContext>;
 }
@@ -65,7 +68,8 @@ export type BasicOptions = DecoratorTypeOptions & DescriptionOptions;
 export type AdvancedOptions = BasicOptions &
   DeprecationOptions &
   SchemaNameOptions &
-  ComplexityOptions;
+  ComplexityOptions &
+  SkipSchemaEmitOptions;
 
 export interface EnumConfig {
   name: string;

--- a/src/helpers/resolver-metadata.ts
+++ b/src/helpers/resolver-metadata.ts
@@ -32,5 +32,6 @@ export function getResolverMetadata(
     description: options.description,
     deprecationReason: options.deprecationReason,
     complexity: options.complexity,
+    skipSchemaEmit: options.skipSchemaEmit,
   };
 }

--- a/src/metadata/definitions/resolver-metadata.ts
+++ b/src/metadata/definitions/resolver-metadata.ts
@@ -27,6 +27,7 @@ export interface ResolverMetadata extends BaseResolverMetadata {
   returnTypeOptions: TypeOptions;
   description?: string;
   deprecationReason?: string;
+  skipSchemaEmit?: boolean;
 }
 
 export interface FieldResolverMetadata extends BaseResolverMetadata {

--- a/src/schema/schema-generator.ts
+++ b/src/schema/schema-generator.ts
@@ -422,6 +422,10 @@ export abstract class SchemaGenerator {
       if (handler.resolverClassMetadata && handler.resolverClassMetadata.isAbstract) {
         return fields;
       }
+      // omit emitting skipped fields
+      if (handler.skipSchemaEmit) {
+        return fields;
+      }
       fields[handler.schemaName] = {
         type: this.getGraphQLOutputType(
           handler.methodName,
@@ -446,6 +450,10 @@ export abstract class SchemaGenerator {
     return subscriptionsHandlers.reduce<GraphQLFieldConfigMap<T, U>>((fields, handler) => {
       // omit emitting abstract resolver fields
       if (handler.resolverClassMetadata && handler.resolverClassMetadata.isAbstract) {
+        return fields;
+      }
+      // omit emitting skipped fields
+      if (handler.skipSchemaEmit) {
         return fields;
       }
 

--- a/tests/functional/generic-types.ts
+++ b/tests/functional/generic-types.ts
@@ -10,7 +10,6 @@ import {
   GraphQLSchema,
   IntrospectionSchema,
   IntrospectionInputObjectType,
-  GraphQLObjectType,
 } from "graphql";
 
 import { getSchemaInfo } from "../helpers/getSchemaInfo";


### PR DESCRIPTION
I ran in to a situation where I wanted a certain resolver to not emit to the schema during the buildSchema command. 

Specifically, I created a factory resolver class, and for certain instantiations, I want delete${item} to be emitted, and for others I do not. 

Having the ability to mark resolver functions as "skipSchemaEmit: True" would be majorly helpful. 

I added in the necessary options and tests, and confirmed everything works as intended. 

BTW: I am still pretty new to coding in general so my tests are not what I would call "elegant"