### PR TITLE
@types/graphql is included with graphql

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,7 +13,7 @@ Before getting started with TypeGraphQL we need to install some additional depen
 First, we have to install the main package, as well as [`graphql-js`](https://github.com/graphql/graphql-js) (and it's typings) which is a peer dependency of TypeGraphQL:
 
 ```sh
-npm i graphql @types/graphql type-graphql
+npm i graphql type-graphql
 ```
 
 Also, the `reflect-metadata` shim is required to make the type reflection work:


### PR DESCRIPTION
In the beginners guide: "installation", it says you need to install @types/graphql. After installing it says: `npm WARN deprecated @types/graphql@14.5.0: This is a stub types definition. graphql provides its own type definitions, so you do not need this installed.` 