### PR TITLE
[fix] ResolverInterface can return null

### DIFF
--- a/src/interfaces/ResolverInterface.ts
+++ b/src/interfaces/ResolverInterface.ts
@@ -3,5 +3,5 @@
  * to provide a proper resolver method signatures for fields of T.
  */
 export type ResolverInterface<T extends object> = {
-  [P in keyof T]?: (root: T, ...args: any[]) => T[P] | Promise<T[P]>
+  [P in keyof T]?: (root: T, ...args: any[]) => T[P] | Promise<T[P]> | null
 };


### PR DESCRIPTION
if `@FieldResolver({nullable: true})` is possible, then shouldn't ResolverInterface allow a null response?