### PR TITLE
docs(container): add InversifyJS side note

### DIFF
--- a/docs/dependency-injection.md
+++ b/docs/dependency-injection.md
@@ -8,7 +8,9 @@ TypeGraphQL supports this technique by allowing users to provide their IoC conta
 
 ## Basic usage
 
-The usage of this feature is very simple - all you need to do is register a 3rd party container. Example using TypeDI:
+The usage of this feature is very simple - all you need to do is register a 3rd party container.
+
+Example using TypeDI:
 
 ```typescript
 import { buildSchema } from "type-graphql";
@@ -69,6 +71,17 @@ export class RecipeService {
 ### Example
 
 You can see how this fits together in the [simple example](https://github.com/MichalLytek/type-graphql/tree/master/examples/using-container).
+
+### InversifyJS
+
+If you are using InversifyJS you need to bind the resolver class with the [self-binding of concrete types](https://github.com/inversify/InversifyJS/blob/master/wiki/classes_as_id.md#self-binding-of-concrete-types). Example:
+
+```typescript
+container
+  .bind<SampleResolver>(SampleResolver)
+  .to(SampleResolver)
+  .inSingletonScope();
+```
 
 ## Scoped containers
 

--- a/docs/dependency-injection.md
+++ b/docs/dependency-injection.md
@@ -68,20 +68,14 @@ export class RecipeService {
 }
 ```
 
-### Example
-
-You can see how this fits together in the [simple example](https://github.com/MichalLytek/type-graphql/tree/master/examples/using-container).
-
-### InversifyJS
-
-If you are using InversifyJS you need to bind the resolver class with the [self-binding of concrete types](https://github.com/inversify/InversifyJS/blob/master/wiki/classes_as_id.md#self-binding-of-concrete-types). Example:
-
-```typescript
-container
-  .bind<SampleResolver>(SampleResolver)
-  .to(SampleResolver)
-  .inSingletonScope();
-```
+> Be aware than when you use [InversifyJS](https://github.com/inversify/InversifyJS), you have to bind the resolver class with the [self-binding of concrete types](https://github.com/inversify/InversifyJS/blob/master/wiki/classes_as_id.md#self-binding-of-concrete-types), e.g.:
+>
+> ```typescript
+> container
+>   .bind<SampleResolver>(SampleResolver)
+>   .to(SampleResolver)
+>   .inSingletonScope();
+> ```
 
 ## Scoped containers
 
@@ -154,6 +148,8 @@ The only thing that's left is the container configuration - we need to check out
 
 > Be aware that some libraries (like `TypeDI`) by default create new instances for every scoped container, so you might experience a **significant increase in memory usage** and some slowing down in query resolving speed, so please be careful with using this feature!
 
-### Example
+## Example
+
+You can see how this fits together in the [simple example](https://github.com/MichalLytek/type-graphql/tree/master/examples/using-container).
 
 For a more advanced usage example with scoped containers, check out [advanced example with scoped containers](https://github.com/MichalLytek/type-graphql/tree/master/examples/using-scoped-container).


### PR DESCRIPTION
Added example:
- add an example in the 'Dependency injection' page that shows the proper way to bind a resolver class if InversifyJS is being used.

The reason I've done this is because I had some trouble to get it working, it wasn't easy to gather information about Inversify and GraphQL, I tried different approaches and that's the only one that worked for me.