### PR TITLE
POC: nested input support

### DIFF
--- a/src/resolvers/convert-arg.ts
+++ b/src/resolvers/convert-arg.ts
@@ -1,0 +1,99 @@
+import { ArgParamMetadata, ClassMetadata } from "../metadata/definitions";
+import { convertToType } from "../helpers/types";
+import { ArgsDictionary } from "../interfaces";
+import { ClassType } from "../interfaces/ClassType";
+import { getMetadataStorage } from "../metadata/getMetadataStorage";
+
+interface InputTypeField {
+  name: string;
+  fields?: InputTypeClass;
+  isArray?: boolean;
+}
+
+interface InputTypeClass {
+  target: ClassType;
+  fields: InputTypeField[];
+}
+
+const generatedTrees = new Map<ClassType, InputTypeClass | null>();
+
+function getInputType(target: ClassType): ClassMetadata | undefined {
+  return getMetadataStorage().inputTypes.find(t => t.target === target);
+}
+
+function generateTree(param: ArgParamMetadata): InputTypeClass | null {
+  const target = param.getType() as ClassType;
+
+  if (generatedTrees.has(target)) {
+    return generatedTrees.get(target) as InputTypeClass;
+  }
+
+  const inputType = getInputType(target);
+
+  if (!inputType) {
+    generatedTrees.set(target, null);
+
+    return null;
+  }
+
+  const generate = (meta: ClassMetadata): InputTypeClass => {
+    const value: InputTypeClass = {
+      target: meta.target as ClassType,
+      fields: (meta.fields || []).map(field => {
+        const fieldInputType = getInputType(field.getType() as ClassType);
+
+        return {
+          name: field.name,
+          fields: fieldInputType ? generate(fieldInputType) : undefined,
+          isArray: field.typeOptions.array === true,
+        };
+      }),
+    };
+
+    const superPrototype = Object.getPrototypeOf(meta.target);
+    if (superPrototype) {
+      const superInputType = getInputType(superPrototype);
+      if (superInputType) {
+        value.fields = value.fields.concat(generate(superInputType).fields);
+      }
+    }
+
+    return value;
+  };
+
+  const tree = generate(inputType);
+
+  generatedTrees.set(target, tree);
+
+  return tree;
+}
+
+function convertToInput(tree: InputTypeClass, data?: any) {
+  const input = new tree.target();
+
+  tree.fields.forEach(field => {
+    if (typeof field.fields !== "undefined") {
+      const siblings = field.fields;
+
+      if (field.isArray) {
+        input[field.name] = (data[field.name] || []).map((value: any) =>
+          convertToInput(siblings, value),
+        );
+      } else {
+        input[field.name] = convertToInput(siblings, data[field.name]);
+      }
+    } else {
+      input[field.name] = data[field.name];
+    }
+  });
+
+  return input;
+}
+
+export function convertToArg(param: ArgParamMetadata, args: ArgsDictionary) {
+  const tree = generateTree(param);
+
+  return tree
+    ? convertToInput(tree, args[param.name])
+    : convertToType(param.getType(), args[param.name]);
+}

--- a/src/resolvers/helpers.ts
+++ b/src/resolvers/helpers.ts
@@ -1,6 +1,5 @@
 import { PubSubEngine } from "graphql-subscriptions";
 import { ValidatorOptions } from "class-validator";
-
 import { ParamMetadata } from "../metadata/definitions";
 import { convertToType } from "../helpers/types";
 import { validateArg } from "./validate-arg";
@@ -8,6 +7,7 @@ import { ResolverData, AuthChecker, AuthMode } from "../interfaces";
 import { Middleware, MiddlewareFn, MiddlewareClass } from "../interfaces/Middleware";
 import { IOCContainer } from "../utils/container";
 import { AuthMiddleware } from "../helpers/auth-middleware";
+import { convertToArg } from "./convert-arg";
 
 export async function getParams(
   params: ParamMetadata[],
@@ -28,7 +28,7 @@ export async function getParams(
             );
           case "arg":
             return await validateArg(
-              convertToType(paramInfo.getType(), resolverData.args[paramInfo.name]),
+              convertToArg(paramInfo, resolverData.args),
               globalValidate,
               paramInfo.validate,
             );


### PR DESCRIPTION
This is an attempt at fixing inputs.

I'm doing this by iterating over the input type fields, checking if the field's type is an input type, and if so, hydrating the argument into the class.  I attempted to make it more performant by caching the tree based off the param metadata's type.