### PR TITLE
Sort emitted schema SDL file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **Breaking Change**: update `graphql-js` peer dependency to `^14.5.8`
 - **Breaking Change**: update `graphql-query-complexity` dependency to `^0.4.1` and drop support for `fieldConfigEstimator` (use `fieldExtensionsEstimator` instead)
 - **Breaking Change**: remove deprecated `DepreciationOptions` interface
+- **Breaking Change**: introduce `sortedSchema` option in `PrintSchemaOptions` and emit sorted schema file by default
 - update `TypeResolver` interface to match with `GraphQLTypeResolver` from `graphql-js`
 - add basic support for directives with `@Directive()` decorator (#369)
 ### Fixes

--- a/docs/emit-schema.md
+++ b/docs/emit-schema.md
@@ -17,6 +17,7 @@ const schema = await buildSchema({
   emitSchemaFile: {
     path: __dirname + "/schema.gql",
     commentDescriptions: true,
+    sortedSchema: false, // by default the printed schema is sorted alphabetically
   },
 });
 ```

--- a/examples/generic-types/schema.gql
+++ b/examples/generic-types/schema.gql
@@ -12,13 +12,13 @@ type Query {
 }
 
 type Recipe {
-  title: String!
   description: String!
   ratings: [Int!]!
+  title: String!
 }
 
 type RecipesResponse {
+  hasMore: Boolean!
   items: [Recipe!]!
   total: Int!
-  hasMore: Boolean!
 }

--- a/examples/interfaces-inheritance/schema.gql
+++ b/examples/interfaces-inheritance/schema.gql
@@ -9,33 +9,33 @@ The javascript `Date` as string. Type represents date and time as the ISO Date s
 scalar DateTime
 
 type Employee implements IPerson {
-  id: ID!
-  name: String!
   age: Int!
   companyName: String!
+  id: ID!
+  name: String!
 }
 
 input EmployeeInput {
-  name: String!
-  dateOfBirth: DateTime!
   companyName: String!
+  dateOfBirth: DateTime!
+  name: String!
 }
 
 interface IPerson {
+  age: Int!
   id: ID!
   name: String!
-  age: Int!
 }
 
 type Mutation {
-  addStudent(input: StudentInput!): Student!
   addEmployee(input: EmployeeInput!): Employee!
+  addStudent(input: StudentInput!): Student!
 }
 
 type Person implements IPerson {
+  age: Int!
   id: ID!
   name: String!
-  age: Int!
 }
 
 type Query {
@@ -43,14 +43,14 @@ type Query {
 }
 
 type Student implements IPerson {
+  age: Int!
   id: ID!
   name: String!
-  age: Int!
   universityName: String!
 }
 
 input StudentInput {
-  name: String!
   dateOfBirth: DateTime!
+  name: String!
   universityName: String!
 }

--- a/examples/mixin-classes/schema.gql
+++ b/examples/mixin-classes/schema.gql
@@ -4,19 +4,19 @@
 # -----------------------------------------------
 
 input AmendUserInput {
-  forename: String!
-  surname: String
   dateOfBirth: DateTime!
   email: String!
+  forename: String!
   id: Int!
+  surname: String
 }
 
 input CreateUserInput {
-  forename: String!
-  surname: String
   dateOfBirth: DateTime!
   email: String!
+  forename: String!
   password: String!
+  surname: String
 }
 
 """
@@ -25,8 +25,8 @@ The javascript `Date` as string. Type represents date and time as the ISO Date s
 scalar DateTime
 
 type Mutation {
-  createUser(input: CreateUserInput!): User!
   amendUser(input: AmendUserInput!): User!
+  createUser(input: CreateUserInput!): User!
 }
 
 type Query {
@@ -34,9 +34,9 @@ type Query {
 }
 
 type User {
-  forename: String!
-  surname: String
   dateOfBirth: DateTime!
   email: String!
+  forename: String!
   id: Int!
+  surname: String
 }

--- a/examples/simple-usage/schema.gql
+++ b/examples/simple-usage/schema.gql
@@ -3,7 +3,9 @@
 # !!!   DO NOT MODIFY THIS FILE BY YOURSELF   !!!
 # -----------------------------------------------
 
-# The javascript `Date` as string. Type represents date and time as the ISO Date string.
+"""
+The javascript `Date` as string. Type represents date and time as the ISO Date string.
+"""
 scalar DateTime
 
 type Mutation {
@@ -13,24 +15,24 @@ type Mutation {
 type Query {
   recipe(title: String!): Recipe
 
-  # Get all the recipes from around the world 
+  """Get all the recipes from around the world """
   recipes: [Recipe!]!
 }
 
-# Object representing cooking recipe
+"""Object representing cooking recipe"""
 type Recipe {
-  title: String!
-  specification: String @deprecated(reason: "Use `description` field instead")
+  averageRating: Float
+  creationDate: DateTime!
 
-  # The recipe description with preparation info
+  """The recipe description with preparation info"""
   description: String
   ratings: [Int!]!
-  creationDate: DateTime!
   ratingsCount(minRate: Int = 0): Int!
-  averageRating: Float
+  specification: String @deprecated(reason: "Use `description` field instead")
+  title: String!
 }
 
 input RecipeInput {
-  title: String!
   description: String
+  title: String!
 }

--- a/examples/typegoose/schema.gql
+++ b/examples/typegoose/schema.gql
@@ -22,9 +22,9 @@ type Query {
 }
 
 type Rate {
-  value: Int!
   date: DateTime!
   user: User!
+  value: Int!
 }
 
 input RateInput {
@@ -34,15 +34,15 @@ input RateInput {
 
 type Recipe {
   _id: ObjectId!
-  title: String!
+  author: User!
   description: String
   ratings: [Rate!]!
-  author: User!
+  title: String!
 }
 
 input RecipeInput {
-  title: String!
   description: String
+  title: String!
 }
 
 type User {

--- a/src/utils/buildSchema.ts
+++ b/src/utils/buildSchema.ts
@@ -1,5 +1,4 @@
 import { GraphQLSchema } from "graphql";
-import { Options as PrintSchemaOptions } from "graphql/utilities/schemaPrinter";
 import * as path from "path";
 
 import { SchemaGenerator, SchemaGeneratorOptions } from "../schema/schema-generator";
@@ -8,10 +7,11 @@ import {
   emitSchemaDefinitionFileSync,
   emitSchemaDefinitionFile,
   defaultPrintSchemaOptions,
+  PrintSchemaOptions,
 } from "./emitSchemaDefinitionFile";
 import { NonEmptyArray } from "./types";
 
-interface EmitSchemaFileOptions extends PrintSchemaOptions {
+interface EmitSchemaFileOptions extends Partial<PrintSchemaOptions> {
   path?: string;
 }
 
@@ -25,6 +25,7 @@ export interface BuildSchemaOptions extends Omit<SchemaGeneratorOptions, "resolv
    */
   emitSchemaFile?: string | boolean | EmitSchemaFileOptions;
 }
+
 export async function buildSchema(options: BuildSchemaOptions): Promise<GraphQLSchema> {
   const resolvers = loadResolvers(options);
   const schema = await SchemaGenerator.generateFromMetadata({ ...options, resolvers });
@@ -77,7 +78,7 @@ function getEmitSchemaDefinitionFileOptions(
         : defaultSchemaFilePath,
     printSchemaOptions:
       typeof buildSchemaOptions.emitSchemaFile === "object"
-        ? buildSchemaOptions.emitSchemaFile
+        ? { ...defaultPrintSchemaOptions, ...buildSchemaOptions.emitSchemaFile }
         : defaultPrintSchemaOptions,
   };
 }

--- a/src/utils/emitSchemaDefinitionFile.ts
+++ b/src/utils/emitSchemaDefinitionFile.ts
@@ -1,9 +1,16 @@
-import { GraphQLSchema, printSchema } from "graphql";
-import { Options as PrintSchemaOptions } from "graphql/utilities/schemaPrinter";
+import { GraphQLSchema, printSchema, lexicographicSortSchema } from "graphql";
+import { Options as GraphQLPrintSchemaOptions } from "graphql/utilities/schemaPrinter";
 
 import { outputFile, outputFileSync } from "../helpers/filesystem";
 
-export const defaultPrintSchemaOptions: PrintSchemaOptions = { commentDescriptions: false };
+export interface PrintSchemaOptions extends Required<GraphQLPrintSchemaOptions> {
+  sortedSchema: boolean;
+}
+
+export const defaultPrintSchemaOptions: PrintSchemaOptions = {
+  commentDescriptions: false,
+  sortedSchema: true,
+};
 
 const generatedSchemaWarning = /* graphql */ `\
 # -----------------------------------------------
@@ -18,7 +25,7 @@ export function emitSchemaDefinitionFileSync(
   schema: GraphQLSchema,
   options: PrintSchemaOptions = defaultPrintSchemaOptions,
 ) {
-  const schemaFileContent = generatedSchemaWarning + printSchema(schema, options);
+  const schemaFileContent = getSchemaFileContent(schema, options);
   outputFileSync(schemaFilePath, schemaFileContent);
 }
 
@@ -27,6 +34,11 @@ export async function emitSchemaDefinitionFile(
   schema: GraphQLSchema,
   options: PrintSchemaOptions = defaultPrintSchemaOptions,
 ) {
-  const schemaFileContent = generatedSchemaWarning + printSchema(schema, options);
+  const schemaFileContent = getSchemaFileContent(schema, options);
   await outputFile(schemaFilePath, schemaFileContent);
+}
+
+function getSchemaFileContent(schema: GraphQLSchema, options: PrintSchemaOptions) {
+  const schemaToEmit = options.sortedSchema ? lexicographicSortSchema(schema) : schema;
+  return generatedSchemaWarning + printSchema(schemaToEmit, options);
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,9 @@
 export { buildSchema, buildSchemaSync, BuildSchemaOptions } from "./buildSchema";
 export { buildTypeDefsAndResolvers } from "./buildTypeDefsAndResolvers";
-export { emitSchemaDefinitionFile, emitSchemaDefinitionFileSync } from "./emitSchemaDefinitionFile";
+export {
+  emitSchemaDefinitionFile,
+  emitSchemaDefinitionFileSync,
+  PrintSchemaOptions,
+  defaultPrintSchemaOptions,
+} from "./emitSchemaDefinitionFile";
 export { ContainerType, ContainerGetter } from "./container";


### PR DESCRIPTION
This PR aims to solve issues #379, #442 and #417.

However because the `lexicographicSortSchema` utility strips off all additional properties from types config, the schema sorting only applies to the emitted schema SDL file for now, on the contrary to @mattiassundling fork: https://github.com/mattiassundling/type-graphql/commit/5a6fbc6e4aeb97a3dd78a3d2a09982109b69ce58

So if you need a sorted schema in GraphQL Playground or other tools that uses introspection and if you don't rely on the putting metadata in the type config, you should use `lexicographicSortSchema` on your own, e.g.:

```ts
transformSchema: (schema: GraphQLSchema) => lexicographicSortSchema(schema)
```