### PR TITLE
Fix browser shim TypeScript argument checking

### DIFF
--- a/src/browser-shim.ts
+++ b/src/browser-shim.ts
@@ -12,8 +12,8 @@ plugins: [
 ]
 */
 
-const dummyFn = () => void 0;
-const dummyDecorator = () => dummyFn;
+const dummyFn = (...args: any[]) => void 0;
+const dummyDecorator = (...args: any[]) => dummyFn;
 
 export const Arg = dummyDecorator;
 export const Args = dummyDecorator;


### PR DESCRIPTION
Some of the decorators in this library take optional arguments. Thus the
shimmed version of the decorator factories should optionally accept
arguments as well.

Also, as documented by
https://www.typescriptlang.org/docs/handbook/decorators.html, the
functions returned by decorator factories may take arguments. Thus the
shimmed version of these functions should optionally accept arguments as
well.