### PR TITLE
Add support for the browser shim in Angular

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -67,6 +67,21 @@ export class Gulpfile {
   }
 
   /**
+   * Copy over the browser-shim files instead of compiling them.
+   * The .js file supports ES5 and newer browsers.
+   * The .ts file supports Angular and other TypeScript projects.
+   */
+  @MergedTask()
+  packageCopyBrowserShim() {
+    return [
+      gulp.src("./src/browser-shim.js")
+      .pipe(gulp.dest("./build/package/dist")),
+      gulp.src("./src/browser-shim.ts")
+      .pipe(gulp.dest("./build/package/dist")),
+    ];
+  }
+
+  /**
    * Moves all compiled files to the final package directory.
    */
   // @Task()
@@ -117,6 +132,7 @@ export class Gulpfile {
     return [
       "clean",
       "packageCompile",
+      "packageCopyBrowserShim",
       // "packageMoveCompiledFiles",
       // "packageClearCompileDirectory",
       ["packagePreparePackageFile", "packageReadmeFile"],

--- a/src/browser-shim.js
+++ b/src/browser-shim.js
@@ -1,0 +1,51 @@
+"use strict";
+/*
+This "shim" can be used on the frontend to prevent from errors on undefined decorators,
+when you are sharing same classes across backend and frontend.
+To use this shim, simply set up your Webpack configuration
+to use this file instead of a normal TypeGraphQL module.
+
+plugins: [
+    // ...here are any other existing plugins that you already have
+    new webpack.NormalModuleReplacementPlugin(/type-graphql$/, resource => {
+        resource.request = resource.request.replace(/type-graphql/, "type-graphql/dist/browser-shim");
+    }),
+]
+*/
+Object.defineProperty(exports, "__esModule", { value: true });
+
+function dummyFn() {
+  void 0;
+}
+function dummyDecorator() {
+  return dummyFn;
+}
+var dummyValue = "";
+
+exports.registerEnumType = dummyFn;
+exports.createUnionType = dummyFn;
+
+exports.Arg = dummyDecorator;
+exports.Args = dummyDecorator;
+exports.ArgsType = dummyDecorator;
+exports.Authorized = dummyDecorator;
+exports.Ctx = dummyDecorator;
+exports.Field = dummyDecorator;
+exports.FieldResolver = dummyDecorator;
+exports.Info = dummyDecorator;
+exports.InputType = dummyDecorator;
+exports.InterfaceType = dummyDecorator;
+exports.Mutation = dummyDecorator;
+exports.ObjectType = dummyDecorator;
+exports.PubSub = dummyDecorator;
+exports.Query = dummyDecorator;
+exports.Resolver = dummyDecorator;
+exports.Root = dummyDecorator;
+exports.Subscription = dummyDecorator;
+exports.UseMiddleware = dummyDecorator;
+
+exports.Int = dummyValue;
+exports.Float = dummyValue;
+exports.ID = dummyValue;
+exports.GraphQLISODateTime = dummyValue;
+exports.GraphQLTimestamp = dummyValue;

--- a/src/browser-shim.ts
+++ b/src/browser-shim.ts
@@ -16,8 +16,11 @@ tsconfig.json:
   }
 }
 
-Note: Exporting dummyFn and dummyDecorator and providing a .ts file
-      instead of a .d.ts file is required by Angular's AoT compiler.
+Note:
+Angular's AoT compiler requires that a full .ts file is provided instead of just
+a .d.ts file so that the full TypeScript function definitions are available.
+It also requires that dummyFn and dummyDecorator are not function expressions
+(i.e. are not lambda functions) and that they are exported.
 */
 
 export function dummyFn(...args: any[]) {

--- a/src/browser-shim.ts
+++ b/src/browser-shim.ts
@@ -1,26 +1,41 @@
 /*
 This "shim" can be used on the frontend to prevent from errors on undefined decorators,
-when you are sharing same classes across backend and frontend.
-To use this shim, simply set up your Webpack configuration
+when you are sharing same classes across backend and frontend in TypeScript projects.
+To use this shim, simply set up your TypeScript configuration
 to use this file instead of a normal TypeGraphQL module.
 
-plugins: [
-    // ...here are any other existing plugins that you already have
-    new webpack.NormalModuleReplacementPlugin(/type-graphql$/, resource => {
-        resource.request = resource.request.replace(/type-graphql/, "type-graphql/dist/browser-shim");
-    }),
-]
+tsconfig.json:
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "type-graphql": [
+        "./node_modules/type-graphql/dist/browser-shim"
+      ]
+    }
+  }
+}
+
+Note: Exporting dummyFn and dummyDecorator and providing a .ts file
+      instead of a .d.ts file is required by Angular's AoT compiler.
 */
 
-const dummyFn = () => void 0;
-const dummyDecorator = () => dummyFn;
+export function dummyFn(...args: any[]) {
+  void 0;
+}
+export function dummyDecorator(...args: any[]) {
+  return dummyFn;
+}
+const dummyValue = "";
+
+export const registerEnumType = dummyFn;
+export const createUnionType = dummyFn;
 
 export const Arg = dummyDecorator;
 export const Args = dummyDecorator;
 export const ArgsType = dummyDecorator;
 export const Authorized = dummyDecorator;
 export const Ctx = dummyDecorator;
-export const registerEnumType = dummyFn;
 export const Field = dummyDecorator;
 export const FieldResolver = dummyDecorator;
 export const Info = dummyDecorator;
@@ -33,5 +48,10 @@ export const Query = dummyDecorator;
 export const Resolver = dummyDecorator;
 export const Root = dummyDecorator;
 export const Subscription = dummyDecorator;
-export const createUnionType = dummyFn;
 export const UseMiddleware = dummyDecorator;
+
+export const Int = dummyValue;
+export const Float = dummyValue;
+export const ID = dummyValue;
+export const GraphQLISODateTime = dummyValue;
+export const GraphQLTimestamp = dummyValue;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -65,6 +65,7 @@
     "./tests"
   ],
   "exclude": [
+    "./src/browser-shim.ts",
     "./examples/apollo-client"
   ]
 }


### PR DESCRIPTION
This supersedes #466 and #467.

Further testing revealed that my previous PRs didn't work with Angular's AoT compiler. This solution fully supports Angular/TypeScript UI projects using browser-shim.ts while keeping support for non-TypeScript UI projects using browser-shim.js (and making that ES5-compatible).

This also should fix #350.