### PR TITLE
Fix duplicated entries for resolver classes that use inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixes
 - refactor union types function syntax handling to prevent possible errors with circular refs
 - fix transforming and validating nested inputs and arrays (#462)
+- remove duplicated entries for resolver classes that use inheritance (#499)
 ### Others
 - **Breaking Change**: change build config to ES2018 - drop support for Node.js < 10.3
 - **Breaking Change**: remove deprecated `DepreciationOptions` interface

--- a/src/metadata/metadata-storage.ts
+++ b/src/metadata/metadata-storage.ts
@@ -263,10 +263,14 @@ export class MetadataStorage {
       while (superResolver.prototype) {
         const superResolverMetadata = this.resolverClasses.find(it => it.target === superResolver);
         if (superResolverMetadata) {
-          mapSuperResolverHandlers(this.queries, superResolver, def);
-          mapSuperResolverHandlers(this.mutations, superResolver, def);
-          mapSuperResolverHandlers(this.subscriptions, superResolver, def);
-          mapSuperFieldResolverHandlers(this.fieldResolvers, superResolver, def);
+          this.queries = mapSuperResolverHandlers(this.queries, superResolver, def);
+          this.mutations = mapSuperResolverHandlers(this.mutations, superResolver, def);
+          this.subscriptions = mapSuperResolverHandlers(this.subscriptions, superResolver, def);
+          this.fieldResolvers = mapSuperFieldResolverHandlers(
+            this.fieldResolvers,
+            superResolver,
+            def,
+          );
         }
         superResolver = Object.getPrototypeOf(superResolver);
       }

--- a/src/metadata/metadata-storage.ts
+++ b/src/metadata/metadata-storage.ts
@@ -263,14 +263,10 @@ export class MetadataStorage {
       while (superResolver.prototype) {
         const superResolverMetadata = this.resolverClasses.find(it => it.target === superResolver);
         if (superResolverMetadata) {
-          this.queries.unshift(...mapSuperResolverHandlers(this.queries, superResolver, def));
-          this.mutations.unshift(...mapSuperResolverHandlers(this.mutations, superResolver, def));
-          this.subscriptions.unshift(
-            ...mapSuperResolverHandlers(this.subscriptions, superResolver, def),
-          );
-          this.fieldResolvers.unshift(
-            ...mapSuperFieldResolverHandlers(this.fieldResolvers, superResolver, def),
-          );
+          mapSuperResolverHandlers(this.queries, superResolver, def);
+          mapSuperResolverHandlers(this.mutations, superResolver, def);
+          mapSuperResolverHandlers(this.subscriptions, superResolver, def);
+          mapSuperFieldResolverHandlers(this.fieldResolvers, superResolver, def);
         }
         superResolver = Object.getPrototypeOf(superResolver);
       }

--- a/src/metadata/utils.ts
+++ b/src/metadata/utils.ts
@@ -20,9 +20,7 @@ export function mapSuperResolverHandlers<T extends BaseResolverMetadata>(
           target: resolverMetadata.target,
           resolverClassMetadata: resolverMetadata,
         }
-      : {
-          ...metadata,
-        };
+      : metadata;
   });
 }
 
@@ -41,7 +39,7 @@ export function mapSuperFieldResolverHandlers(
             ? resolverMetadata.getObjectType
             : metadata.getObjectType,
         }
-      : { ...metadata };
+      : metadata;
   });
 }
 

--- a/src/metadata/utils.ts
+++ b/src/metadata/utils.ts
@@ -15,26 +15,26 @@ export function mapSuperResolverHandlers<T extends BaseResolverMetadata>(
 ): T[] {
   const superMetadata = definitions.filter(subscription => subscription.target === superResolver);
 
-  return superMetadata.map<T>(metadata => ({
-    ...(metadata as any),
-    target: resolverMetadata.target,
-    resolverClassMetadata: resolverMetadata,
-  }));
+  // modify objects by reference so as not to create duplicates
+  superMetadata.forEach(metadata => {
+    metadata.target = resolverMetadata.target;
+    metadata.resolverClassMetadata = resolverMetadata;
+  });
+  return superMetadata;
 }
 
 export function mapSuperFieldResolverHandlers(
   definitions: FieldResolverMetadata[],
   superResolver: Function,
   resolverMetadata: ResolverClassMetadata,
-): FieldResolverMetadata[] {
+) {
   const superMetadata = mapSuperResolverHandlers(definitions, superResolver, resolverMetadata);
 
-  return superMetadata.map<FieldResolverMetadata>(metadata => ({
-    ...metadata,
-    getObjectType: isThrowing(metadata.getObjectType!)
-      ? resolverMetadata.getObjectType!
-      : metadata.getObjectType!,
-  }));
+  superMetadata.forEach(metadata => {
+    metadata.getObjectType = isThrowing(metadata.getObjectType!)
+      ? resolverMetadata.getObjectType
+      : metadata.getObjectType;
+  });
 }
 
 export function mapMiddlewareMetadataToArray(

--- a/src/metadata/utils.ts
+++ b/src/metadata/utils.ts
@@ -13,14 +13,17 @@ export function mapSuperResolverHandlers<T extends BaseResolverMetadata>(
   superResolver: Function,
   resolverMetadata: ResolverClassMetadata,
 ): T[] {
-  const superMetadata = definitions.filter(subscription => subscription.target === superResolver);
-
-  // modify objects by reference so as not to create duplicates
-  superMetadata.forEach(metadata => {
-    metadata.target = resolverMetadata.target;
-    metadata.resolverClassMetadata = resolverMetadata;
+  return definitions.map(metadata => {
+    return metadata.target === superResolver
+      ? {
+          ...metadata,
+          target: resolverMetadata.target,
+          resolverClassMetadata: resolverMetadata,
+        }
+      : {
+          ...metadata,
+        };
   });
-  return superMetadata;
 }
 
 export function mapSuperFieldResolverHandlers(
@@ -30,10 +33,15 @@ export function mapSuperFieldResolverHandlers(
 ) {
   const superMetadata = mapSuperResolverHandlers(definitions, superResolver, resolverMetadata);
 
-  superMetadata.forEach(metadata => {
-    metadata.getObjectType = isThrowing(metadata.getObjectType!)
-      ? resolverMetadata.getObjectType
-      : metadata.getObjectType;
+  return superMetadata.map(metadata => {
+    return metadata.target === superResolver
+      ? {
+          ...metadata,
+          getObjectType: isThrowing(metadata.getObjectType!)
+            ? resolverMetadata.getObjectType
+            : metadata.getObjectType,
+        }
+      : { ...metadata };
   });
 }
 

--- a/tests/functional/metadata-storage.ts
+++ b/tests/functional/metadata-storage.ts
@@ -1,0 +1,157 @@
+import "reflect-metadata";
+
+import { getMetadataStorage } from "../../src/metadata/getMetadataStorage";
+import {
+  Resolver,
+  Query,
+  buildSchema,
+  Mutation,
+  Subscription,
+  FieldResolver,
+  ObjectType,
+  ClassType,
+  Field,
+} from "../../src";
+import { MetadataStorage } from "../../src/metadata/metadata-storage";
+
+describe("MetadataStorage", () => {
+  let metadataStorage: MetadataStorage;
+  const INHERITED_QUERY_NAME = "inheritedQueryName";
+  const INHERITED_MUTATION_NAME = "inheritedMutationName";
+  const INHERITED_SUBSCRIPTION_NAME = "inheritedSubscriptionName";
+  const INHERITED_FIELD_RESOLVER_NAME = "inheritedFieldResolverName";
+
+  beforeAll(async () => {
+    metadataStorage = getMetadataStorage();
+    metadataStorage.clear();
+
+    function createAbstractResolver(classType: ClassType) {
+      @Resolver(() => classType, { isAbstract: true })
+      abstract class AbstractResolver {
+        @Query({ name: INHERITED_QUERY_NAME })
+        abstractQuery(): boolean {
+          return true;
+        }
+
+        @Mutation({ name: INHERITED_MUTATION_NAME })
+        abstractMutation(): boolean {
+          return true;
+        }
+
+        @Subscription({ name: INHERITED_SUBSCRIPTION_NAME, topics: "sampleTopic" })
+        abstractSubscription(): boolean {
+          return true;
+        }
+
+        @FieldResolver({ name: INHERITED_FIELD_RESOLVER_NAME })
+        abstractFieldResolver(): boolean {
+          return true;
+        }
+      }
+      return AbstractResolver;
+    }
+
+    @ObjectType()
+    class SampleObject {
+      @Field()
+      sampleField: boolean;
+
+      @Field({ name: INHERITED_FIELD_RESOLVER_NAME })
+      abstractSampleField: boolean;
+    }
+
+    @Resolver(() => SampleObject)
+    class SubClassResolver extends createAbstractResolver(SampleObject) {
+      @Query()
+      subClassQuery(): boolean {
+        return true;
+      }
+
+      @Mutation()
+      subClassMutation(): boolean {
+        return true;
+      }
+
+      @Subscription({ topics: "sampleTopic" })
+      subClassSubscription(): boolean {
+        return true;
+      }
+
+      @FieldResolver()
+      sampleField(): boolean {
+        return true;
+      }
+    }
+
+    await buildSchema({ resolvers: [SubClassResolver] });
+  });
+
+  it("should not have duplicate fieldResolver metadata", async () => {
+    function countItems() {
+      const qNameCount: { [key: string]: number } = {};
+      metadataStorage.fieldResolvers.forEach((q: any) => {
+        qNameCount[q.schemaName] === undefined
+          ? (qNameCount[q.schemaName] = 1)
+          : qNameCount[q.schemaName]++;
+      });
+      console.log("Field Resolver Count By Name", qNameCount);
+    }
+    countItems();
+    expect(
+      metadataStorage.fieldResolvers.filter(
+        fieldResolver => fieldResolver.schemaName === INHERITED_FIELD_RESOLVER_NAME,
+      ).length,
+    ).toBe(1);
+  });
+
+  it("should not have duplicate subscription metadata for resolvers", async () => {
+    function countItems() {
+      const qNameCount: { [key: string]: number } = {};
+      metadataStorage.subscriptions.forEach((q: any) => {
+        qNameCount[q.schemaName] === undefined
+          ? (qNameCount[q.schemaName] = 1)
+          : qNameCount[q.schemaName]++;
+      });
+      console.log("Subscription Count By Name", qNameCount);
+    }
+    countItems();
+    expect(
+      metadataStorage.subscriptions.filter(
+        subscription => subscription.schemaName === INHERITED_SUBSCRIPTION_NAME,
+      ).length,
+    ).toBe(1);
+  });
+
+  it("should not have duplicate mutation metadata for resolvers", async () => {
+    function countItems() {
+      const qNameCount: { [key: string]: number } = {};
+      metadataStorage.mutations.forEach((q: any) => {
+        qNameCount[q.schemaName] === undefined
+          ? (qNameCount[q.schemaName] = 1)
+          : qNameCount[q.schemaName]++;
+      });
+      console.log("Mutation Count By Name", qNameCount);
+    }
+    countItems();
+    expect(
+      metadataStorage.mutations.filter(mutation => mutation.schemaName === INHERITED_MUTATION_NAME)
+        .length,
+    ).toBe(1);
+  });
+
+  it("should not have duplicate query metadata for resolvers", async () => {
+    function countItems() {
+      const qNameCount: { [key: string]: number } = {};
+      metadataStorage.queries.forEach((q: any) => {
+        qNameCount[q.schemaName] === undefined
+          ? (qNameCount[q.schemaName] = 1)
+          : qNameCount[q.schemaName]++;
+      });
+      console.log("Query Count By Name", qNameCount);
+    }
+    countItems();
+    expect(
+      metadataStorage.queries.filter(query => query.schemaName === INHERITED_QUERY_NAME).length,
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
This is an attempt to at least partially solve what I believe is a memory leak issue regarding metadata-storage. 

If you're using a workflow where you build the schema dynamically on every request the `queries` and `mutations` arrays that are properties of the global metadata storage instance quickly grow in size for classes utilizing inheritance. From what I can tell it filters for the objects it's looking for in order to copy and modify metadata from the parent resolver class but creates new entries and adds them to an ever growing list. This solution simply modifies those object in place relying on pass by reference so that the array doesn't grow forever and cause memory issues as well as degraded performance on each subsequent request.

In my workflow simply clearing the global metadata cache didn't work because I have 2 schemas. 1 which is created statically when the app is started and then an additional schema which is created dynamically on each request. Clearing the cache broke my static schema.

This PR only partially solves the issue though as the `queries` list does seem to continue to grow (all be it much more slowly) adding a single duplicate item for each `@Query` or `@Mutation` decorator that I call during the dynamic creation of the schema. For example:

```typescript
function makeResolver(type: ClassType, msg: string) {
  @Resolver(() => type)
  class DynamicResolver {

    @Query(() => GraphQLString, { name: `hello${msg}` })
    hello() {
       return `hello ${msg}`;
    }  
  }
}
```
Every time I prepare the Resolvers before calling `buildSchema` the `Query` decorator executes and adds a new item the my list of queries. This would be fine & necessary if I were intending to keep the schemas around for future use but they are meant to be thrown away after each request .

I'm using Containers and reseting after each request but the metadata storage appears to be global and it's not clear to me currently whether there is even a way to associate metadata items with the id of a container so that perhaps they could be cleared more individually at the same time you reset the container.

Perhaps my use case is rather uncommon or perhaps I'm missing something but I think this PR solves a bug that is there regardless of my particular use cases as you can see duplicate items without even having build the schema multiple times. Any guidance you might have on how I could clear other items from the metadata storage based on Container ID or what I might attempt in terms of an approach to make a PR to support this would be greatly appreciated!

Thanks for the amazing library!