### PR TITLE
Update bootstrap docs

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -63,6 +63,8 @@ async function bootstrap() {
 bootstrap(); // actually run the async function
 ```
 
+NOTE: once the resolvers are compiled, the resolver path(s) will no longer be valid for `*.ts` files and instead will need to reference the compiled `*.js` files.
+
 ## Create an HTTP GraphQL endpoint
 
 In most cases, the GraphQL app is served by an HTTP server. After building the schema we can create the GraphQL endpoint with a variety of tools such as [`graphql-yoga`](https://github.com/prisma/graphql-yoga) or [`apollo-server`](https://github.com/apollographql/apollo-server). Here is an example using [`apollo-server`](https://github.com/apollographql/apollo-server):

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -39,7 +39,7 @@ So we can also provide an array of paths to resolver module files instead, which
 
 ```typescript
 const schema = await buildSchema({
-  resolvers: [__dirname + "/modules/**/*.resolver.ts", __dirname + "/resolvers/**/*.ts"],
+  resolvers: [__dirname + "/modules/**/*.resolver.{ts,js}", __dirname + "/resolvers/**/*.{ts,js}"],
 });
 ```
 
@@ -54,7 +54,7 @@ import { buildSchema } from "type-graphql";
 
 async function bootstrap() {
   const schema = await buildSchema({
-    resolvers: [__dirname + "/**/*.resolver.ts"],
+    resolvers: [__dirname + "/**/*.resolver.{ts,js}"],
   });
 
   // other initialization code, like creating http server
@@ -62,8 +62,6 @@ async function bootstrap() {
 
 bootstrap(); // actually run the async function
 ```
-
-NOTE: once the resolvers are compiled, the resolver path(s) will no longer be valid for `*.ts` files and instead will need to reference the compiled `*.js` files.
 
 ## Create an HTTP GraphQL endpoint
 

--- a/website/versioned_docs/version-0.17.1/bootstrap.md
+++ b/website/versioned_docs/version-0.17.1/bootstrap.md
@@ -26,7 +26,7 @@ So we can also provide an array of paths to resolver module files instead, which
 
 ```typescript
 const schema = await buildSchema({
-  resolvers: [__dirname + "/modules/**/*.resolver.ts", __dirname + "/resolvers/**/*.ts"],
+  resolvers: [__dirname + "/modules/**/*.resolver.{ts,js}", __dirname + "/resolvers/**/*.{ts,js}"],
 });
 ```
 
@@ -39,7 +39,7 @@ import { buildSchema } from "type-graphql";
 
 async function bootstrap() {
   const schema = await buildSchema({
-    resolvers: [__dirname + "/**/*.resolver.ts"],
+    resolvers: [__dirname + "/**/*.resolver.{ts,js}"],
   });
 
   // other initialization code, like creating http server


### PR DESCRIPTION
Adding a note that the examples indicate .ts files for the resolver paths, but once the files are compiled (ie in production environments), the paths will be .js not .ts files.