### PR TITLE
Find scalars by name in convertTypeIfScalar

### DIFF
--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -18,7 +18,9 @@ export function convertTypeIfScalar(type: any): GraphQLScalarType | undefined {
   if (type instanceof GraphQLScalarType) {
     return type;
   }
-  const scalarMap = BuildContext.scalarsMaps.find(it => it.type === type);
+  const scalarMap = BuildContext.scalarsMaps.find(
+    it => it.type === type || it.scalar.toString() === type.toString(),
+  );
   if (scalarMap) {
     return scalarMap.scalar;
   }


### PR DESCRIPTION
## Problem
I am building a [CLI](https://github.com/tristanMatthias/brix/) that uses this amazing repo (Thanks! 🎉), but I've been having an issue with:

https://github.com/MichalLytek/type-graphql/blob/master/src/helpers/types.ts#L18

This issue is when a global package uses input scalars from the same package, but one is installed locally and the other is global, the check fails and I get a nasty error:

```
UnhandledPromiseRejectionWarning: Error: Cannot determine GraphQL input type for data
```

## Solution
This very tiny solution allows for an additional lookup by the name of the scalar itself. That way, no matter what version, or where it's loaded from, it will still resolve.