### PR TITLE
Fix interface resolvers with custom schemaName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - fix transforming and validating nested inputs and arrays (#462)
 - remove duplicated entries for resolver classes that use inheritance (#499)
 - **Breaking Change**: stop returning null for `GraphQLTimestamp` and `GraphQLISODateTime` scalars when returned value is not a `Date` instance - now it throws explicit error instead
+- fix using `name` option on interface fields (#567)
 ### Others
 - **Breaking Change**: change build config to ES2018 - drop support for Node.js < 10.3
 - **Breaking Change**: remove deprecated `DepreciationOptions` interface

--- a/src/schema/schema-generator.ts
+++ b/src/schema/schema-generator.ts
@@ -16,7 +16,6 @@ import {
   GraphQLUnionType,
   GraphQLTypeResolver,
   GraphQLDirective,
-  defaultFieldResolver,
 } from "graphql";
 import { withFilter, ResolverFn } from "graphql-subscriptions";
 

--- a/src/schema/schema-generator.ts
+++ b/src/schema/schema-generator.ts
@@ -235,15 +235,7 @@ export abstract class SchemaGenerator {
                   fieldsMap[field.schemaName] = {
                     description: field.description,
                     type: this.getGraphQLOutputType(field.name, field.getType(), field.typeOptions),
-                    resolve: (source, args, contextValue, info) => {
-                      if (field.name !== field.schemaName) {
-                        return defaultFieldResolver(source, args, contextValue, {
-                          ...info,
-                          fieldName: field.name,
-                        });
-                      }
-                      return defaultFieldResolver(source, args, contextValue, info);
-                    },
+                    resolve: createBasicFieldResolver(field),
                   };
                   return fieldsMap;
                 },

--- a/src/schema/schema-generator.ts
+++ b/src/schema/schema-generator.ts
@@ -16,6 +16,7 @@ import {
   GraphQLUnionType,
   GraphQLTypeResolver,
   GraphQLDirective,
+  defaultFieldResolver,
 } from "graphql";
 import { withFilter, ResolverFn } from "graphql-subscriptions";
 
@@ -234,6 +235,15 @@ export abstract class SchemaGenerator {
                   fieldsMap[field.schemaName] = {
                     description: field.description,
                     type: this.getGraphQLOutputType(field.name, field.getType(), field.typeOptions),
+                    resolve: (source, args, contextValue, info) => {
+                      if (field.name !== field.schemaName) {
+                        return defaultFieldResolver(source, args, contextValue, {
+                          ...info,
+                          fieldName: field.name,
+                        });
+                      }
+                      return defaultFieldResolver(source, args, contextValue, info);
+                    },
                   };
                   return fieldsMap;
                 },

--- a/tests/functional/interfaces-and-inheritance.ts
+++ b/tests/functional/interfaces-and-inheritance.ts
@@ -473,10 +473,14 @@ describe("Interfaces and inheritance", () => {
       abstract class BaseInterface {
         @Field()
         baseInterfaceField: string;
+
+        @Field({ name: "renamedInterfaceField", nullable: true })
+        interfaceFieldToBeRenamed?: string;
       }
       @ObjectType({ implements: BaseInterface })
       class FirstImplementation implements BaseInterface {
         baseInterfaceField: string;
+        interfaceFieldToBeRenamed?: string;
         @Field()
         firstField: string;
       }
@@ -624,6 +628,15 @@ describe("Interfaces and inheritance", () => {
             secondField: "secondField",
           };
         }
+
+        @Query()
+        renamedFieldInterfaceQuery(): BaseInterface {
+          const obj = new FirstImplementation();
+          obj.baseInterfaceField = "baseInterfaceField";
+          obj.firstField = "firstField";
+          obj.interfaceFieldToBeRenamed = "interfaceFieldToBeRenamed";
+          return obj;
+        }
       }
 
       schema = await buildSchema({
@@ -743,6 +756,21 @@ describe("Interfaces and inheritance", () => {
       const data = result.data!.getFirstInterfaceImplementationObject;
       expect(data.baseInterfaceField).toEqual("baseInterfaceField");
       expect(data.firstField).toEqual("firstField");
+    });
+
+    it("should allow interfaces to specify custom schema names", async () => {
+      const query = `query {
+        renamedFieldInterfaceQuery {
+          renamedInterfaceField
+        }
+      }`;
+
+      const { data, errors } = await graphql(schema, query);
+
+      expect(errors).toBeUndefined();
+      expect(data!.renamedFieldInterfaceQuery.renamedInterfaceField).toEqual(
+        "interfaceFieldToBeRenamed",
+      );
     });
 
     it("should pass args data of extended args class", async () => {


### PR DESCRIPTION
Fixes #566 

New to this codebase, open to feedback!

~~As an aside, the [`defaultFieldResolver` function](https://github.com/graphql/graphql-js/blob/fe878eef98aba23df988e858dbafa029d6351bd1/src/execution/execute.js#L1187) just does the _check if this is a function, if so, call it, otherwise return it as is_ thing.~~

**Edit:** I changed to use the `createBasicFieldResolver` function. It looks like it could also be extended to the advanced resolver type to support external interface resolvers? Also, I think that the status quo (before this PR) wouldn't apply any auth checking to fields defined on interfaces since it doesn't run any middlewares.