### PR TITLE
Fix `@Authorized` in subscriptions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - remove duplicated entries for resolver classes that use inheritance (#499)
 - **Breaking Change**: stop returning null for `GraphQLTimestamp` and `GraphQLISODateTime` scalars when returned value is not a `Date` instance - now it throws explicit error instead
 - fix using `name` option on interface fields (#567)
+- fix not calling `authChecker` during subscribe phase for subscriptions (#578)
 ### Others
 - **Breaking Change**: change build config to ES2018 - drop support for Node.js < 10.3
 - **Breaking Change**: remove deprecated `DepreciationOptions` interface


### PR DESCRIPTION
This PR adds proper `authChecker` call for subscriptions.
Now auth is also checked during subscribe phase to reject unauthorized clients, not only when pubsub emit new event in selected topic (when subscription method body is called). 

Closes #175 🔒 