### PR TITLE
Automatically register object types implementing used interface type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - optimize resolvers execution paths to speed up a lot basic scenarios (#488)
 - add `@Extensions` decorator for putting metadata into GraphQL types config (#521)
 - add support for defining arguments and implementing resolvers for interface types fields (#579)
+- add `{ autoRegisterImplementations: false }` option to prevent automatic emitting in schema all the object types that implements used interface type (#595)
 ### Fixes
 - refactor union types function syntax handling to prevent possible errors with circular refs
 - fix transforming and validating nested inputs and arrays (#462)

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -9,7 +9,7 @@ After creating our resolvers, type classes, and other business-related code, we 
 To create an executable schema from type and resolver definitions, we need to use the `buildSchema` function.
 It takes a configuration object as a parameter and returns a promise of a `GraphQLSchema` object.
 
-In the configuration object you must provide a `resolvers` property, which can be an array of resolver classes:
+In the configuration object we must provide a `resolvers` property, which can be an array of resolver classes:
 
 ```typescript
 import { FirstResolver, SecondResolver } from "../app/src/resolvers";
@@ -21,7 +21,7 @@ const schema = await buildSchema({
 
 Be aware that only operations (queries, mutation, etc.) defined in the resolvers classes (and types directly connected to them) will be emitted in schema.
 
-So if you e.g. have defined some object types that implements an interface but are not directly used in other types definition (like a part of an union, a type of a field or a return type of an operation), you need to provide them manually in `orphanedTypes` options of `buildSchema`:
+So if we have defined some object types (that implements an interface type [with disabled auto registering](interfaces.md#registering-in-schema)) but are not directly used in other types definition (like a part of an union, a type of a field or a return type of an operation), we need to provide them manually in `orphanedTypes` options of `buildSchema`:
 
 ```typescript
 import { FirstResolver, SecondResolver } from "../app/src/resolvers";

--- a/src/decorators/InterfaceType.ts
+++ b/src/decorators/InterfaceType.ts
@@ -2,7 +2,15 @@ import { getMetadataStorage } from "../metadata/getMetadataStorage";
 import { getNameDecoratorParams } from "../helpers/decorators";
 import { DescriptionOptions, AbstractClassOptions, ResolveTypeOptions } from "./types";
 
-export type InterfaceTypeOptions = DescriptionOptions & AbstractClassOptions & ResolveTypeOptions;
+export type InterfaceTypeOptions = DescriptionOptions &
+  AbstractClassOptions &
+  ResolveTypeOptions & {
+    /**
+     * Set to false to prevent emitting in schema all object types
+     * that implements this interface type.
+     */
+    autoRegisterImplementations?: boolean;
+  };
 
 export function InterfaceType(): ClassDecorator;
 export function InterfaceType(options: InterfaceTypeOptions): ClassDecorator;
@@ -16,6 +24,7 @@ export function InterfaceType(
     getMetadataStorage().collectInterfaceMetadata({
       name: name || target.name,
       target,
+      autoRegisteringDisabled: options.autoRegisterImplementations === false,
       ...options,
     });
   };

--- a/src/metadata/definitions/interface-class-metadata.ts
+++ b/src/metadata/definitions/interface-class-metadata.ts
@@ -3,4 +3,5 @@ import { TypeResolver } from "../../interfaces";
 
 export interface InterfaceClassMetadata extends ClassMetadata {
   resolveType?: TypeResolver<any, any>;
+  autoRegisteringDisabled: boolean;
 }

--- a/tests/functional/generic-types.ts
+++ b/tests/functional/generic-types.ts
@@ -81,7 +81,9 @@ describe("Generic types", () => {
 
     @ObjectType({ implements: SampleInterfaceType })
     class SampleType implements SampleInterfaceType {
+      @Field()
       baseField: string;
+      @Field()
       sampleField: string;
     }
 

--- a/tests/helpers/getSchemaInfo.ts
+++ b/tests/helpers/getSchemaInfo.ts
@@ -9,7 +9,11 @@ import { buildSchema, BuildSchemaOptions } from "../../src";
 
 export async function getSchemaInfo(options: BuildSchemaOptions) {
   // build schema from definitions
-  const schema = await buildSchema(options);
+  const schema = await buildSchema({
+    ...options,
+    validate: false,
+    skipCheck: true,
+  });
 
   // get builded schema info from retrospection
   const result = await graphql(schema, getIntrospectionQuery());


### PR DESCRIPTION
This PR adds a feature that automatically emit in schema all the object types that implements the interface types referenced in schema definition.

It also adds an option to disable the auto register feature per interface type, like the `Node` interface case for Relay-based system, in case of multiple schemas isolation.

Closes #568