### PR TITLE
fix: add RxJS dependency to NestJS demo

### DIFF
--- a/examples/3-nest-js/package-lock.json
+++ b/examples/3-nest-js/package-lock.json
@@ -2077,6 +2077,7 @@
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
+        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -3224,6 +3225,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -5139,6 +5146,14 @@
       "optional": true,
       "requires": {
         "aproba": "^1.1.1"
+      }
+    },
+    "rxjs": {
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
+      "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
+      "requires": {
+        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {

--- a/examples/3-nest-js/package.json
+++ b/examples/3-nest-js/package.json
@@ -14,6 +14,7 @@
     "apollo-server-fastify": "^2.12.0",
     "graphql": "^14.6.0",
     "reflect-metadata": "^0.1.13",
+    "rxjs": "^6.5.5",
     "type-graphql": "0.18.0-beta.16",
     "typegraphql-nestjs": "^0.1.2"
   },


### PR DESCRIPTION
Hey @MichalLytek, thanks for your work on TypeGraphQL, this new version looks super promising combined with Prisma!

When testing the NestJS example I ran into an error:

```
$ ts-node --transpile-only ./index.ts
Error: Cannot find module 'rxjs'
Require stack:
- /Users/beeman/kikstart/scratch/type-graphql/examples/3-nest-js/node_modules/@nestjs/common/cache/interceptors/cache.interceptor.js
- /Users/beeman/kikstart/scratch/type-graphql/examples/3-nest-js/node_modules/@nestjs/common/cache/interceptors/index.js
- /Users/beeman/kikstart/scratch/type-graphql/examples/3-nest-js/node_modules/@nestjs/common/cache/index.js
- /Users/beeman/kikstart/scratch/type-graphql/examples/3-nest-js/node_modules/@nestjs/common/index.js
- /Users/beeman/kikstart/scratch/type-graphql/examples/3-nest-js/node_modules/typegraphql-nestjs/dist/typegraphql.module.js
- /Users/beeman/kikstart/scratch/type-graphql/examples/3-nest-js/node_modules/typegraphql-nestjs/dist/index.js
- /Users/beeman/kikstart/scratch/type-graphql/examples/3-nest-js/index.ts
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:981:15)
    at Function.Module._load (internal/modules/cjs/loader.js:863:27)
    at Module.require (internal/modules/cjs/loader.js:1043:19)
    at require (internal/modules/cjs/helpers.js:77:18)
    at Object.<anonymous> (/Users/beeman/kikstart/scratch/type-graphql/examples/3-nest-js/node_modules/@nestjs/common/cache/interceptors/cache.interceptor.js:4:16)
    at Module._compile (internal/modules/cjs/loader.js:1157:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1177:10)
    at Module.load (internal/modules/cjs/loader.js:1001:32)
    at Function.Module._load (internal/modules/cjs/loader.js:900:14)
    at Module.require (internal/modules/cjs/loader.js:1043:19)
error Command failed with exit code 1.
```


This patch fixes it. 