### PR TITLE
fix(schema): Fix directives cannot be extends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 <!-- ## Unreleased -->
 <!-- here goes all the unreleased changes descriptions -->
+- fix `@Directive()` cannot be extends by subclasses 
 
 ## v1.0.0-rc.1
 ### Features
@@ -31,7 +32,6 @@
 - fix calling field resolver without providing resolver class to `buildSchema`
 - fix generated TS union type for union type of object type classes extending themselves (#587)
 - fix using shared union and interface types in multiple schemas when `resolveType` is used
-- fix `@Directive()` cannot be extends by subclasses 
 ### Others
 - **Breaking Change**: change build config to ES2018 - drop support for Node.js < 10.3
 - **Breaking Change**: remove deprecated `DepreciationOptions` interface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - fix calling field resolver without providing resolver class to `buildSchema`
 - fix generated TS union type for union type of object type classes extending themselves (#587)
 - fix using shared union and interface types in multiple schemas when `resolveType` is used
+- fix `@Directive()` cannot be extends by subclasses 
 ### Others
 - **Breaking Change**: change build config to ES2018 - drop support for Node.js < 10.3
 - **Breaking Change**: remove deprecated `DepreciationOptions` interface

--- a/src/schema/utils.ts
+++ b/src/schema/utils.ts
@@ -15,6 +15,7 @@ export function getFieldMetadataFromInputType(type: GraphQLInputObjectType) {
       const superField = fieldInfo[fieldName];
       fieldsMap[fieldName] = {
         type: superField.type,
+        astNode: superField.astNode,
         description: superField.description,
         defaultValue: superField.defaultValue,
       };
@@ -36,6 +37,7 @@ export function getFieldMetadataFromObjectType(type: GraphQLObjectType | GraphQL
           argMap[name] = arg;
           return argMap;
         }, {}),
+        astNode: superField.astNode,
         resolve: superField.resolve,
         description: superField.description,
         deprecationReason: superField.deprecationReason,

--- a/tests/functional/directives.ts
+++ b/tests/functional/directives.ts
@@ -396,7 +396,7 @@ describe("Directives", () => {
         assertValidDirective(fields.append.astNode, "upper");
       });
 
-      it("adds field directives to subclass input type fields", async () => {
+      it("adds inherited field directives to input type fields while extending input type class", async () => {
         const fields = (schema.getType(
           "SubDirectiveOnFieldInput",
         ) as GraphQLInputObjectType).getFields();
@@ -445,7 +445,7 @@ describe("Directives", () => {
         });
       });
 
-      it("calls subclass object type directives", async () => {
+      it("call object type directives while extending field type class", async () => {
         const query = `query {
           subObjectType {
             withDirective

--- a/tests/functional/directives.ts
+++ b/tests/functional/directives.ts
@@ -37,6 +37,9 @@ describe("Directives", () => {
       }
 
       @InputType()
+      class SubDirectiveOnFieldInput extends DirectiveOnFieldInput {}
+
+      @InputType()
       @Directive("@upper")
       class DirectiveOnClassInput {
         @Field()
@@ -93,6 +96,14 @@ describe("Directives", () => {
         @Field()
         @Directive("upper")
         withInputUpperOnClass(@Arg("input") input: DirectiveOnClassInput): string {
+          return `hello${input.append}`;
+        }
+      }
+
+      @ObjectType()
+      class SubSampleObjectType extends SampleObjectType {
+        @Field()
+        withInput(@Arg("input") input: SubDirectiveOnFieldInput): string {
           return `hello${input.append}`;
         }
       }
@@ -206,8 +217,16 @@ describe("Directives", () => {
         }
       }
 
+      @Resolver(of => SubSampleObjectType)
+      class SubSampleResolver {
+        @Query(() => SubSampleObjectType)
+        subObjectType(): SubSampleObjectType {
+          return new SubSampleObjectType();
+        }
+      }
+
       schema = await buildSchema({
-        resolvers: [SampleResolver, SampleObjectTypeResolver],
+        resolvers: [SampleResolver, SampleObjectTypeResolver, SubSampleResolver],
       });
 
       SchemaDirectiveVisitor.visitSchemaDirectives(schema, {
@@ -378,6 +397,18 @@ describe("Directives", () => {
       });
     });
 
+    describe("SubInputType", () => {
+      it("adds field directives to input type fields", async () => {
+        const fields = (schema.getType(
+          "SubDirectiveOnFieldInput",
+        ) as GraphQLInputObjectType).getFields();
+
+        expect(fields).toHaveProperty("append");
+        expect(fields.append).toHaveProperty("astNode");
+        assertValidDirective(fields.append.astNode, "upper");
+      });
+    });
+
     describe("ObjectType", () => {
       it("calls object type directives", async () => {
         const query = `query {
@@ -401,6 +432,45 @@ describe("Directives", () => {
 
         expect(data).toHaveProperty("objectType");
         expect(data!.objectType).toEqual({
+          withDirective: "withDirective",
+          // withDirectiveWithArgs: "withDirectiveWithArgs",
+          withUpper: "WITHUPPER",
+          withUpperDefinition: "WITHUPPERDEFINITION",
+          withAppend: "hello, world!",
+          withAppendDefinition: "hello, world!",
+          withUpperAndAppend: "HELLO, WORLD!",
+          withInput: "hello, WORLD!",
+          withInputUpper: "HELLO, WORLD!",
+          withInputOnClass: "hello, WORLD!",
+          withInputUpperOnClass: "HELLO, WORLD!",
+          fieldResolverWithAppendDefinition: "hello, world!",
+        });
+      });
+    });
+
+    describe("SubObjectType", () => {
+      it("calls object type directives", async () => {
+        const query = `query {
+          subObjectType {
+            withDirective
+            # withDirectiveWithArgs
+            withUpper
+            withUpperDefinition
+            withAppend(append: ", world!")
+            withAppendDefinition(append: ", world!")
+            withUpperAndAppend(append: ", world!")
+            withInput(input: { append: ", world!" })
+            withInputUpper(input: { append: ", world!" })
+            withInputOnClass(input: { append: ", world!" })
+            withInputUpperOnClass(input: { append: ", world!" })
+            fieldResolverWithAppendDefinition(append: ", world!")
+          }
+      }`;
+
+        const { data } = await graphql(schema, query);
+
+        expect(data).toHaveProperty("subObjectType");
+        expect(data!.subObjectType).toEqual({
           withDirective: "withDirective",
           // withDirectiveWithArgs: "withDirectiveWithArgs",
           withUpper: "WITHUPPER",

--- a/tests/functional/directives.ts
+++ b/tests/functional/directives.ts
@@ -395,10 +395,8 @@ describe("Directives", () => {
         expect(fields.append).toHaveProperty("astNode");
         assertValidDirective(fields.append.astNode, "upper");
       });
-    });
 
-    describe("SubInputType", () => {
-      it("adds field directives to input type fields", async () => {
+      it("adds field directives to subclass input type fields", async () => {
         const fields = (schema.getType(
           "SubDirectiveOnFieldInput",
         ) as GraphQLInputObjectType).getFields();
@@ -446,10 +444,8 @@ describe("Directives", () => {
           fieldResolverWithAppendDefinition: "hello, world!",
         });
       });
-    });
 
-    describe("SubObjectType", () => {
-      it("calls object type directives", async () => {
+      it("calls subclass object type directives", async () => {
         const query = `query {
           subObjectType {
             withDirective


### PR DESCRIPTION
For Example:

```typescript
@ObjectType({ isAbstract: true })
class INode {
    @Field(() => ID)
    id!: string

    @Directive('@formatDate')
    @Field(() => Timestamp)
    createdAt: Date;

    @Directive('@formatDate')
    @Field(() => Timestamp)
    updatedAt: Date;
}

//  People class cannot extends INode Filed directives  
@ObjectType()
class People extends INode {

}
```