### PR TITLE
Add info about shim for cypress

### DIFF
--- a/docs/browser-usage.md
+++ b/docs/browser-usage.md
@@ -6,7 +6,7 @@ title: Browser usage
 
 Sometimes we might want to use the classes we've created and annotated with TypeGraphQL decorators, in our client app that works in the browser. For example, reusing the args or input classes with `class-validator` decorators or the object type classes with some helpful custom methods.
 
-Since TypeGraphQL is a Node.js framework, it doesn't work in a browser environment, so we may quickly get an error, e.g. `ERROR in ./node_modules/fs.realpath/index.js`, while trying to build our app with Webpack. To correct this, we have to configure Webpack to use the decorator shim instead of the normal module. We simply add this plugin code to our webpack config:
+Since TypeGraphQL is a Node.js framework, it doesn't work in a browser environment, so we may quickly get an error, e.g. `ERROR in ./node_modules/fs.realpath/index.js` or `utils1_promisify is not a function`, while trying to build our app with Webpack. To correct this, we have to configure Webpack to use the decorator shim instead of the normal module. We simply add this plugin code to our webpack config:
 
 ```js
 module.exports = {
@@ -19,6 +19,8 @@ module.exports = {
   ];
 }
 ```
+
+In case of cypress, you can adapt the same webpack config trick just by applying the [cypress-webpack-preprocessor](https://github.com/cypress-io/cypress-webpack-preprocessor) plugin.
 
 However, in some TypeScript projects like the ones using Angular, which AoT compiler requires that a full `*.ts` file is provided instead of just a `*.js` and `*.d.ts` files, to use this shim we have to simply set up our TypeScript configuration in `tsconfig.json` to use this file instead of a normal TypeGraphQL module:
 
@@ -34,27 +36,3 @@ However, in some TypeScript projects like the ones using Angular, which AoT comp
 ```
 
 Thanks to this, our bundle will be much lighter as we don't need to embed the whole TypeGraphQL library code in our app.
-
-## Usage with Cypress Tests
-
-If you're importing a module into your test which includes a type-graphql decorator you need to tell Cypress's webpack config to shim type-graphl.
-
-First `yarn add --dev webpack @cypress/webpack-preprocessor ts-loader`. Note: You might already have one or more of these installed - delete as required.
-
-Then in `cypress/plugins/index.js` just add this to your config:
-
-```js
-module.exports = (on, config) => {
-  const { NormalModuleReplacementPlugin } = require('webpack')
-  const options = {
-    webpackOptions: {
-      plugins: [
-        new NormalModuleReplacementPlugin(/type-graphql$/, resource => {
-          resource.request = resource.request.replace(/type-graphql/, "type-graphql/dist/browser-shim.js");
-        }),
-      ];
-    },
-  }
-  on('file:preprocessor', wp(options));
-}
-```

--- a/docs/browser-usage.md
+++ b/docs/browser-usage.md
@@ -34,3 +34,27 @@ However, in some TypeScript projects like the ones using Angular, which AoT comp
 ```
 
 Thanks to this, our bundle will be much lighter as we don't need to embed the whole TypeGraphQL library code in our app.
+
+## Usage with Cypress Tests
+
+If you're importing a module into your test which includes a type-graphql decorator you need to tell Cypress's webpack config to shim type-graph.
+
+First `yarn add --dev webpack @cypress/webpack-preprocessor ts-loader`. Note: You might already have one or more of these installed - delete as required.
+
+Then in `cypress/plugins/index.js` just add this to your config:
+
+```js
+module.exports = (on, config) => {
+  const { NormalModuleReplacementPlugin } = require('webpack')
+  const options = {
+    webpackOptions: {
+      plugins: [
+        new NormalModuleReplacementPlugin(/type-graphql$/, resource => {
+          resource.request = resource.request.replace(/type-graphql/, "type-graphql/dist/browser-shim.js");
+        }),
+      ];
+    },
+  }
+  on('file:preprocessor', wp(options));
+}
+```

--- a/docs/browser-usage.md
+++ b/docs/browser-usage.md
@@ -37,7 +37,7 @@ Thanks to this, our bundle will be much lighter as we don't need to embed the wh
 
 ## Usage with Cypress Tests
 
-If you're importing a module into your test which includes a type-graphql decorator you need to tell Cypress's webpack config to shim type-graph.
+If you're importing a module into your test which includes a type-graphql decorator you need to tell Cypress's webpack config to shim type-graphl.
 
 First `yarn add --dev webpack @cypress/webpack-preprocessor ts-loader`. Note: You might already have one or more of these installed - delete as required.
 


### PR DESCRIPTION
I've had to do the same browser shim in cypress because I am using a module which exports the type-graphql decorators. This PR adds that info to the docs.