### PR TITLE
docs: add initial contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,11 +21,12 @@ If you would like to chat about the question in real-time, you can reach out via
 ## <a name="issue"></a> Found a Bug?
 
 If you find a bug in the source code, you can help us by [submitting an issue](#submit-issue) to our [GitHub Repository][github].
-Even better, you can [submit a Pull Request](#submit-pr) with a fix.
+Even better, you can [submit a Pull Request](#submit-pr) with a failing test case that reproduces the issue.
 
 ## <a name="feature"></a> Missing a Feature?
 
 You can _request_ a new feature by [submitting an issue](#submit-issue) to our GitHub Repository.
+
 If you would like to _implement_ a new feature, please consider the size of the change in order to determine the right steps to proceed:
 
 - For a **Major Feature**, first open an issue and outline your proposal so that it can be discussed.
@@ -80,7 +81,8 @@ Before you submit your Pull Request (PR) consider the following guidelines:
    git push origin my-fix-branch
    ```
 
-10. In GitHub, send a pull request to `type-graphql:master`. Make sure to [allow edits from maintainers][allow-maintainer-edits].
+10. In GitHub, send a pull request to `type-graphql:master`.
+Make sure to [allow edits from maintainers][allow-maintainer-edits].
 
 If we ask for changes via code reviews then:
 
@@ -127,11 +129,13 @@ After your pull request is merged, you can safely delete your branch and pull th
 
 To ensure consistency throughout the source code, keep these rules in mind as you are working:
 
-- All features or bug fixes **must be tested** by one or more unit tests.
+- All features or bug fixes **must be covered by tests**.
+
+- The code must pass type checking and fullfil all the TSLint rules.
 
 ## <a name="commit"></a> Commit Message Guidelines
 
-For more information checkout this [commit rule guide](https://gist.github.com/stephenparish/9941e89d80e2bc58a153).
+For more information checkout this [commit rules guide](https://www.conventionalcommits.org/en/v1.0.0/).
 
 [github]: https://github.com/MichalLytek/type-graphql
 [gitter]: https://gitter.im/type-graphql/Lobby

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,13 +3,12 @@
 We would love for you to contribute to TypeGraphQL and help make it even better than it is today!
 As a contributor, here are the guidelines we would like you to follow:
 
- - [Question or Problem?](#question)
- - [Issues and Bugs](#issue)
- - [Feature Requests](#feature)
- - [Submission Guidelines](#submit)
- - [Coding Rules](#rules)
- - [Commit Message Guidelines](#commit)
-
+- [Question or Problem?](#question)
+- [Issues and Bugs](#issue)
+- [Feature Requests](#feature)
+- [Submission Guidelines](#submit)
+- [Coding Rules](#rules)
+- [Commit Message Guidelines](#commit)
 
 ## <a name="question"></a> Got a Question or Problem?
 
@@ -19,32 +18,28 @@ Instead, consider using [Stack Overflow](https://stackoverflow.com/questions/tag
 
 If you would like to chat about the question in real-time, you can reach out via [our gitter channel][gitter].
 
-
 ## <a name="issue"></a> Found a Bug?
 
 If you find a bug in the source code, you can help us by [submitting an issue](#submit-issue) to our [GitHub Repository][github].
 Even better, you can [submit a Pull Request](#submit-pr) with a fix.
 
-
 ## <a name="feature"></a> Missing a Feature?
-You can *request* a new feature by [submitting an issue](#submit-issue) to our GitHub Repository.
-If you would like to *implement* a new feature, please consider the size of the change in order to determine the right steps to proceed:
 
-* For a **Major Feature**, first open an issue and outline your proposal so that it can be discussed.
+You can _request_ a new feature by [submitting an issue](#submit-issue) to our GitHub Repository.
+If you would like to _implement_ a new feature, please consider the size of the change in order to determine the right steps to proceed:
+
+- For a **Major Feature**, first open an issue and outline your proposal so that it can be discussed.
   This process allows us to better coordinate our efforts, prevent duplication of work, and help you to craft the change so that it is successfully accepted into the project.
 
-* **Small Features** can be crafted and directly [submitted as a Pull Request](#submit-pr).
-
+- **Small Features** can be crafted and directly [submitted as a Pull Request](#submit-pr).
 
 ## <a name="submit"></a> Submission Guidelines
-
 
 ### <a name="submit-issue"></a> Submitting an Issue
 
 Before you submit an issue, please search the issue tracker. An issue for your problem may already exist and the discussion might inform you of workarounds readily available.
 
 You can file new issues by selecting from our [new issue templates](https://github.com/MichalLytek/type-graphql/issues/new/choose) and filling out the issue template.
-
 
 ### <a name="submit-pr"></a> Submitting a Pull Request (PR)
 
@@ -60,9 +55,9 @@ Before you submit your Pull Request (PR) consider the following guidelines:
 
 4. Make your changes in a new git branch:
 
-     ```shell
-     git checkout -b my-fix-branch master
-     ```
+   ```shell
+   git checkout -b my-fix-branch master
+   ```
 
 5. Create your patch, **including appropriate test cases**.
 
@@ -73,74 +68,70 @@ Before you submit your Pull Request (PR) consider the following guidelines:
 8. Commit your changes using a descriptive commit message that follows our [commit message guidelines](#commit).
    Adherence to these conventions is necessary because release notes are automatically generated from these messages.
 
-     ```shell
-     git commit -a
-     ```
-    Note: the optional commit `-a` command line option will automatically "add" and "rm" edited files.
+   ```shell
+   git commit -a
+   ```
+
+   Note: the optional commit `-a` command line option will automatically "add" and "rm" edited files.
 
 9. Push your branch to GitHub:
 
-    ```shell
-    git push origin my-fix-branch
-    ```
+   ```shell
+   git push origin my-fix-branch
+   ```
 
 10. In GitHub, send a pull request to `type-graphql:master`. Make sure to [allow edits from maintainers][allow-maintainer-edits].
 
-   If we ask for changes via code reviews then:
+If we ask for changes via code reviews then:
 
-   * Make the required updates.
-   * Re-run the test suites to ensure tests are still passing.
-   * Rebase your branch and force push to your GitHub repository (this will update your Pull Request):
+- Make the required updates.
+- Re-run the test suites to ensure tests are still passing.
+- Rebase your branch and force push to your GitHub repository (this will update your Pull Request):
 
-      ```shell
-      git rebase master -i
-      git push -f
-      ```
+  ```shell
+  git rebase master -i
+  git push -f
+  ```
 
 That's it! Thank you for your contribution!
-
 
 #### After your pull request is merged
 
 After your pull request is merged, you can safely delete your branch and pull the changes from the main (upstream) repository:
 
-* Delete the remote branch on GitHub either through the GitHub web UI or your local shell as follows:
+- Delete the remote branch on GitHub either through the GitHub web UI or your local shell as follows:
 
-    ```shell
-    git push origin --delete my-fix-branch
-    ```
+  ```shell
+  git push origin --delete my-fix-branch
+  ```
 
-* Check out the master branch:
+- Check out the master branch:
 
-    ```shell
-    git checkout master -f
-    ```
+  ```shell
+  git checkout master -f
+  ```
 
-* Delete the local branch:
+- Delete the local branch:
 
-    ```shell
-    git branch -D my-fix-branch
-    ```
+  ```shell
+  git branch -D my-fix-branch
+  ```
 
-* Update your master with the latest upstream version:
+- Update your master with the latest upstream version:
 
-    ```shell
-    git pull --ff upstream master
-    ```
-
+  ```shell
+  git pull --ff upstream master
+  ```
 
 ## <a name="rules"></a> Coding Rules
+
 To ensure consistency throughout the source code, keep these rules in mind as you are working:
 
-* All features or bug fixes **must be tested** by one or more unit tests.
-
+- All features or bug fixes **must be tested** by one or more unit tests.
 
 ## <a name="commit"></a> Commit Message Guidelines
 
 For more information checkout this [commit rule guide](https://gist.github.com/stephenparish/9941e89d80e2bc58a153).
-
-
-
 
 [github]: https://github.com/MichalLytek/type-graphql
 [gitter]: https://gitter.im/type-graphql/Lobby

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,148 @@
+# Contributing to TypeGraphQL
+
+We would love for you to contribute to TypeGraphQL and help make it even better than it is today!
+As a contributor, here are the guidelines we would like you to follow:
+
+ - [Question or Problem?](#question)
+ - [Issues and Bugs](#issue)
+ - [Feature Requests](#feature)
+ - [Submission Guidelines](#submit)
+ - [Coding Rules](#rules)
+ - [Commit Message Guidelines](#commit)
+
+
+## <a name="question"></a> Got a Question or Problem?
+
+Do not open issues for general support questions as we want to keep GitHub issues for bug reports and feature requests.
+
+Instead, consider using [Stack Overflow](https://stackoverflow.com/questions/tagged/typegraphql) to ask support-related questions. When creating a new question on Stack Overflow, make sure to add the `typegraphql` tag.
+
+If you would like to chat about the question in real-time, you can reach out via [our gitter channel][gitter].
+
+
+## <a name="issue"></a> Found a Bug?
+
+If you find a bug in the source code, you can help us by [submitting an issue](#submit-issue) to our [GitHub Repository][github].
+Even better, you can [submit a Pull Request](#submit-pr) with a fix.
+
+
+## <a name="feature"></a> Missing a Feature?
+You can *request* a new feature by [submitting an issue](#submit-issue) to our GitHub Repository.
+If you would like to *implement* a new feature, please consider the size of the change in order to determine the right steps to proceed:
+
+* For a **Major Feature**, first open an issue and outline your proposal so that it can be discussed.
+  This process allows us to better coordinate our efforts, prevent duplication of work, and help you to craft the change so that it is successfully accepted into the project.
+
+* **Small Features** can be crafted and directly [submitted as a Pull Request](#submit-pr).
+
+
+## <a name="submit"></a> Submission Guidelines
+
+
+### <a name="submit-issue"></a> Submitting an Issue
+
+Before you submit an issue, please search the issue tracker. An issue for your problem may already exist and the discussion might inform you of workarounds readily available.
+
+You can file new issues by selecting from our [new issue templates](https://github.com/MichalLytek/type-graphql/issues/new/choose) and filling out the issue template.
+
+
+### <a name="submit-pr"></a> Submitting a Pull Request (PR)
+
+Before you submit your Pull Request (PR) consider the following guidelines:
+
+1. Search [GitHub](https://github.com/MichalLytek/type-graphql/pulls) for an open or closed PR that relates to your submission.
+   You don't want to duplicate existing efforts.
+
+2. Be sure that an issue describes the problem you're fixing, or documents the design for the feature you'd like to add.
+   Discussing the design upfront helps to ensure that we're ready to accept your work.
+
+3. Fork this repo.
+
+4. Make your changes in a new git branch:
+
+     ```shell
+     git checkout -b my-fix-branch master
+     ```
+
+5. Create your patch, **including appropriate test cases**.
+
+6. Follow our [Coding Rules](#rules).
+
+7. Run the full test suite, and ensure that all tests pass.
+
+8. Commit your changes using a descriptive commit message that follows our [commit message guidelines](#commit).
+   Adherence to these conventions is necessary because release notes are automatically generated from these messages.
+
+     ```shell
+     git commit -a
+     ```
+    Note: the optional commit `-a` command line option will automatically "add" and "rm" edited files.
+
+9. Push your branch to GitHub:
+
+    ```shell
+    git push origin my-fix-branch
+    ```
+
+10. In GitHub, send a pull request to `type-graphql:master`. Make sure to [allow edits from maintainers][allow-maintainer-edits].
+
+   If we ask for changes via code reviews then:
+
+   * Make the required updates.
+   * Re-run the test suites to ensure tests are still passing.
+   * Rebase your branch and force push to your GitHub repository (this will update your Pull Request):
+
+      ```shell
+      git rebase master -i
+      git push -f
+      ```
+
+That's it! Thank you for your contribution!
+
+
+#### After your pull request is merged
+
+After your pull request is merged, you can safely delete your branch and pull the changes from the main (upstream) repository:
+
+* Delete the remote branch on GitHub either through the GitHub web UI or your local shell as follows:
+
+    ```shell
+    git push origin --delete my-fix-branch
+    ```
+
+* Check out the master branch:
+
+    ```shell
+    git checkout master -f
+    ```
+
+* Delete the local branch:
+
+    ```shell
+    git branch -D my-fix-branch
+    ```
+
+* Update your master with the latest upstream version:
+
+    ```shell
+    git pull --ff upstream master
+    ```
+
+
+## <a name="rules"></a> Coding Rules
+To ensure consistency throughout the source code, keep these rules in mind as you are working:
+
+* All features or bug fixes **must be tested** by one or more unit tests.
+
+
+## <a name="commit"></a> Commit Message Guidelines
+
+For more information checkout this [commit rule guide](https://gist.github.com/stephenparish/9941e89d80e2bc58a153).
+
+
+
+
+[github]: https://github.com/MichalLytek/type-graphql
+[gitter]: https://gitter.im/type-graphql/Lobby
+[stackoverflow]: https://stackoverflow.com/questions/tagged/typegraphql
+[allow-maintainer-edits]: https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests

--- a/README.md
+++ b/README.md
@@ -180,14 +180,9 @@ It doesn't have a large company that sits behind - its ongoing development is po
 [![](https://opencollective.com/typegraphql/sponsors.svg?width=890&button=false)](https://opencollective.com/typegraphql#contributors)
 [![](https://opencollective.com/typegraphql/backers.svg?width=890&button=false)](https://opencollective.com/typegraphql#contributors)
 
-### Contribution
+### Want to help?
 
-If you have any questions, you can [ask on gitter](https://gitter.im/type-graphql/Lobby).
-If you find a bug, please report it as an issue on GitHub.
+Want to file a bug, contribute some code, or improve documentation? Great! Please read our
+guidelines for [contributing][contributing] and then check out one of our [help wanted issues](https://github.com/MichalLytek/type-graphql/labels/Help%20Wanted%20%3Asos%3A).
 
-If you want to add a new big feature, please create a proposal first, where we can discuss the idea and implementation details. This will prevent wasted time if the PR be rejected.
-
-PRs are welcome, but first check, test and build your code before committing it.
-
-- Use commit rules: For more information checkout this [commit rule guide](https://gist.github.com/stephenparish/9941e89d80e2bc58a153).
-- [Allowing changes to a pull request branch created from a fork](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/)
+[contributing]: https://github.com/MichalLytek/type-graphql/blob/master/CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ It doesn't have a large company that sits behind - its ongoing development is po
 [![](https://opencollective.com/typegraphql/sponsors.svg?width=890&button=false)](https://opencollective.com/typegraphql#contributors)
 [![](https://opencollective.com/typegraphql/backers.svg?width=890&button=false)](https://opencollective.com/typegraphql#contributors)
 
-### Want to help?
+## Want to help?
 
 Want to file a bug, contribute some code, or improve documentation? Great! Please read our
 guidelines for [contributing][contributing] and then check out one of our [help wanted issues](https://github.com/MichalLytek/type-graphql/labels/Help%20Wanted%20%3Asos%3A).


### PR DESCRIPTION
## Purpose
Expand the contributing guidelines into their own dedicated documentation section, to help streamline and guide future contributions.

## Related Issue
Closes #682.
