### PR TITLE
fix: Confusing error wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - allow passing custom validation function as `validate` option to `buildSchema`
 ### Fixes
 - don't include in schema the fields declared as `@FieldResolver` when that resolvers classes aren't provided in `resolvers` array
+- fix grammar in `CannotDetermineGraphQLTypeError` error message
 
 ## v1.0.0
 ### Features

--- a/src/errors/CannotDetermineGraphQLTypeError.ts
+++ b/src/errors/CannotDetermineGraphQLTypeError.ts
@@ -14,8 +14,8 @@ export class CannotDetermineGraphQLTypeError extends Error {
     }
     errorMessage +=
       `'${propertyKey}' of '${typeName}' class. ` +
-      `Does the value used as its TS type or explicit type is decorated with a proper decorator ` +
-      `or is it a proper ${typeKind} value?`;
+      `Is the value, that is used as its TS type or explicit type, decorated with a proper ` +
+      `decorator or is it a proper ${typeKind} value?`;
 
     super(errorMessage);
     Object.setPrototypeOf(this, new.target.prototype);

--- a/tests/functional/resolvers.ts
+++ b/tests/functional/resolvers.ts
@@ -985,7 +985,7 @@ describe("Resolvers", () => {
           expect(err).toBeInstanceOf(CannotDetermineGraphQLTypeError);
           const error = err as CannotDetermineGraphQLTypeError;
           expect(error.message).toMatchInlineSnapshot(
-            `"Cannot determine GraphQL output type for 'sampleQuery' of 'SampleResolverWithError' class. Does the value used as its TS type or explicit type is decorated with a proper decorator or is it a proper output value?"`,
+            `"Cannot determine GraphQL output type for 'sampleQuery' of 'SampleResolverWithError' class. Is the value, that is used as its TS type or explicit type, decorated with a proper decorator or is it a proper output value?"`,
           );
         }
       });
@@ -1015,7 +1015,7 @@ describe("Resolvers", () => {
           expect(err).toBeInstanceOf(CannotDetermineGraphQLTypeError);
           const error = err as CannotDetermineGraphQLTypeError;
           expect(error.message).toMatchInlineSnapshot(
-            `"Cannot determine GraphQL input type for argument named 'input' of 'sampleQuery' of 'SampleResolverWithError' class. Does the value used as its TS type or explicit type is decorated with a proper decorator or is it a proper input value?"`,
+            `"Cannot determine GraphQL input type for argument named 'input' of 'sampleQuery' of 'SampleResolverWithError' class. Is the value, that is used as its TS type or explicit type, decorated with a proper decorator or is it a proper input value?"`,
           );
         }
       });


### PR DESCRIPTION
The existing error message was slightly confusing to me. It caused me to re-read the message several times to understand it.

I felt like a slight change in wording could improve the readability.