### PR TITLE
Found a typo in repository name

### DIFF
--- a/website/pages/snippets/testability.md
+++ b/website/pages/snippets/testability.md
@@ -19,7 +19,7 @@ export class RecipeResolver {
 
   @FieldResolver()
   ratings(@Root() recipe: Recipe) {
-    return this.ratingsRepository.find({ recipeId: recipe.id });
+    return this.rateRepository.find({ recipeId: recipe.id });
   }
 }
 ```


### PR DESCRIPTION
Found a typo. The rate repository is called *rateRepository* in the constructor however is used as *ratingsRepository* in ratings function.