### PR TITLE
fix: Allow `readonly string[]` for `Subscription` topics

### DIFF
--- a/src/decorators/Subscription.ts
+++ b/src/decorators/Subscription.ts
@@ -13,7 +13,7 @@ import { MissingSubscriptionTopicsError } from "../errors";
 import { MergeExclusive } from "../utils/types";
 
 interface PubSubOptions {
-  topics: string | string[] | SubscriptionTopicFunc;
+  topics: string | readonly string[] | SubscriptionTopicFunc;
   filter?: SubscriptionFilterFunc;
 }
 

--- a/src/decorators/types.ts
+++ b/src/decorators/types.ts
@@ -25,7 +25,7 @@ export type SubscriptionFilterFunc = (
 
 export type SubscriptionTopicFunc = (
   resolverTopicData: ResolverTopicData<any, any, any>,
-) => string | string[];
+) => string | readonly string[];
 
 export interface DecoratorTypeOptions {
   nullable?: boolean | NullableListOptions;

--- a/src/metadata/definitions/resolver-metadata.ts
+++ b/src/metadata/definitions/resolver-metadata.ts
@@ -43,7 +43,7 @@ export interface FieldResolverMetadata extends BaseResolverMetadata {
 }
 
 export interface SubscriptionResolverMetadata extends ResolverMetadata {
-  topics: string | string[] | SubscriptionTopicFunc | undefined;
+  topics: string | readonly string[] | SubscriptionTopicFunc | undefined;
   filter: SubscriptionFilterFunc | undefined;
   subscribe: ResolverFn | undefined;
 }

--- a/tests/functional/subscriptions.ts
+++ b/tests/functional/subscriptions.ts
@@ -71,7 +71,7 @@ describe("Subscriptions", () => {
           return true;
         }
 
-        @Subscription(returns => [SampleObject], { topics: "STH" })
+        @Subscription(returns => [SampleObject], { topics: ["STH"] as const })
         subscriptionWithExplicitType(): any {
           return true;
         }
@@ -206,7 +206,7 @@ describe("Subscriptions", () => {
           return { value };
         }
 
-        @Subscription({ topics: [SAMPLE_TOPIC, OTHER_TOPIC] })
+        @Subscription({ topics: [SAMPLE_TOPIC, OTHER_TOPIC] as const })
         multipleTopicSubscription(@Root() value: number): SampleObject {
           return { value };
         }


### PR DESCRIPTION
I just ran into this while attempting to pass something like `['Topic1', 'Topic2'] as const` to subscription options - there's no reason to restrict to mutable arrays here.