### PR TITLE
use optional chaining to get value inside reflectedType

### DIFF
--- a/src/helpers/findType.ts
+++ b/src/helpers/findType.ts
@@ -41,7 +41,7 @@ export function findType({
     propertyKey,
   );
   if (metadataKey === "design:paramtypes") {
-    metadataDesignType = (reflectedType as Function[])[parameterIndex!];
+    metadataDesignType = (reflectedType as Function[])?.[parameterIndex!];
   } else {
     metadataDesignType = reflectedType as Function | undefined;
   }


### PR DESCRIPTION
**Describe the Bug**
I'm not sure if it is a bug, or my specific use case.
I'm creating a custom decorator that inject a generic find function as  field function in the ObjectType class. to achive it i'm using the Args decorator as a function but it throws a error in runtine.

> Cannot read property '0' of undefined


**To Reproduce**
```ts
@ArgsType()
class Ca{
   @Field(() => String)
   a: string;
}

@ObjectType()
class A {
    @ConnectionField( () => ProductFindArgs )
    prueba;
}

export function ConnectionField( findArgs: any, options?: FieldOptions ) {
	return function ConnectionDecorator( target: any, propertyKey: string | symbol ) {
		const newPropertyName = `_${String( propertyKey )}Connection`;
		const field = Field( () => String , { name: String( propertyKey ) } );
		const args = Args(findArgs);
		target[newPropertyName] = async function ConnectionFieldResolver( { a }: any ) {
			return findMany( a );
		};
		const descriptor :PropertyDescriptor = { configurable: true, enumerable: true, writable: true };
		args( target, newPropertyName, 0 );
		field( target, newPropertyName, descriptor );
	};
}
```

**Expected Behavior**
I expected that it create  a function to resolve prueba field inside object type, but it throws a error

I can resolve the problem just adding a optional chaining in line 11 inside /dist/helpers/findType.js , just like 
```ts
 metadataDesignType = reflectedType?.[parameterIndex];

```

**Logs**
at .../node_modules/type-graphql/dist/helpers/findType.js:11
        metadataDesignType = reflectedType[parameterIndex];
                                          ^
TypeError: Cannot read property '0' of undefined
    at .../node_modules/type-graphql/dist/helpers/findType.js:11:43)
    at Object.getParamInfo (.../node_modules/type-graphql/dist/helpers/params.js:10:49)
    at. .../node_modules/type-graphql/dist/decorators/Args.js:12:25


**Environment (please complete the following information):**

- OS: mac os 
- Node 14.0
- Package version  lastest
- TypeScript version  4.0.3

