### PR TITLE
docs(interfaces): clarify chained interface syntax

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -71,12 +71,16 @@ class Node {
 }
 
 @InterfaceType({ implements: Node })
-class Person extends Node {
-  @Field()
-  name: string;
+class IPerson extends Node {
 
   @Field(type => Int)
   age: number;
+}
+
+@ObjectType({ implements: [Node, IPerson] })
+class Person extends IPerson {  
+  @Field()
+  name: string;
 }
 ```
 
@@ -87,7 +91,12 @@ interface Node {
   id: ID!
 }
 
-interface Person implements Node {
+interface IPerson implements Node {
+  id: ID!
+  age: Int!
+}
+
+type Person implements Node & IPerson {
   id: ID!
   name: String!
   age: Int!


### PR DESCRIPTION
Update the doc of a chained interfaces design.

With : 

```ts
@ObjectType({ implements: [IPerson] }) // it miss Node here
class Person extends IPerson {  
  @Field()
  name: string;
}
```

as a `Person` declaration the id type from `Node` will be missing in the Person type and the graphql schema will be wrong with the following error : 

```bash
Type Person must implement Node because it is implemented by IPerson.
Interface field IPerson.id expected but Person does not provide it.
```

Without this exemple, it took me a certain time to figure this error out.

PS: thx a lot for your lib :) 