### PR TITLE
docs(subscriptions): fix arguments of the `subscribe` option

### DIFF
--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -62,7 +62,7 @@ All we need to do is to use the the `subscribe` option which should be a functio
 class SampleResolver {
   // ...
   @Subscription({
-    subscribe: ({ args, context }) => {
+    subscribe: (root, args, context, info) => {
       return context.prisma.$subscribe.users({ mutation_in: [args.mutationType] });
     },
   })


### PR DESCRIPTION
This PR fixes the docs for the function arguments of the `subscribe` option (as per the `ResolverFn` [signature](https://github.com/apollographql/graphql-subscriptions/blob/master/src/with-filter.ts#L4)).