### PR TITLE
Add directives support to Interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 - **Breaking Change**: `AuthChecker` type is now "function or class" - update to `AuthCheckerFn` if the function form is needed in the code
 - support class-based auth checker, which allows for dependency injection
+- allow defining directives for interface types and theirs fields, with inheritance for object types fields (#744)
 
 ## v1.1.1
 ### Fixes

--- a/docs/directives.md
+++ b/docs/directives.md
@@ -32,7 +32,7 @@ Basically, we declare the usage of directives just like in SDL, with the `@` syn
 @Directive('@deprecated(reason: "Use newField")')
 ```
 
-Currently, you can use the directives only on object types, input types and their fields or fields resolvers, as well as queries, mutations and subscriptions.
+Currently, you can use the directives only on object types, input types, interface types and their fields or fields resolvers, as well as queries, mutations and subscriptions. Other locations like scalars, enums, unions or arguments are not yet supported. 
 
 So the `@Directive` decorator can be placed over the class property/method or over the type class itself, depending on the needs and the placements supported by the implementation:
 

--- a/src/schema/definition-node.ts
+++ b/src/schema/definition-node.ts
@@ -9,6 +9,7 @@ import {
   parseValue,
   DocumentNode,
   parse,
+  InterfaceTypeDefinitionNode,
 } from "graphql";
 
 import { InvalidDirectiveError } from "../errors";
@@ -98,6 +99,25 @@ export function getInputValueDefinitionNode(
     },
     name: {
       kind: "Name",
+      value: name,
+    },
+    directives: directiveMetadata.map(getDirectiveNode),
+  };
+}
+
+export function getInterfaceTypeDefinitionNode(
+  name: string,
+  directiveMetadata?: DirectiveMetadata[],
+): InterfaceTypeDefinitionNode | undefined {
+  if (!directiveMetadata || !directiveMetadata.length) {
+    return;
+  }
+
+  return {
+    kind: "InterfaceTypeDefinition",
+    name: {
+      kind: "Name",
+      // FIXME: use proper AST representation
       value: name,
     },
     directives: directiveMetadata.map(getDirectiveNode),

--- a/src/schema/schema-generator.ts
+++ b/src/schema/schema-generator.ts
@@ -52,6 +52,7 @@ import {
   getFieldDefinitionNode,
   getInputObjectTypeDefinitionNode,
   getInputValueDefinitionNode,
+  getInterfaceTypeDefinitionNode,
   getObjectTypeDefinitionNode,
 } from "./definition-node";
 import { ObjectClassMetadata } from "../metadata/definitions/object-class-metdata";
@@ -392,6 +393,7 @@ export abstract class SchemaGenerator {
           type: new GraphQLInterfaceType({
             name: interfaceType.name,
             description: interfaceType.description,
+            astNode: getInterfaceTypeDefinitionNode(interfaceType.name, interfaceType.directives),
             interfaces: () => {
               let interfaces = (interfaceType.interfaceClasses || []).map<GraphQLInterfaceType>(
                 interfaceClass =>
@@ -431,19 +433,21 @@ export abstract class SchemaGenerator {
                       (resolver.resolverClassMetadata === undefined ||
                         resolver.resolverClassMetadata.isAbstract === false),
                   );
+                  const type = this.getGraphQLOutputType(
+                    field.target,
+                    field.name,
+                    field.getType(),
+                    field.typeOptions,
+                  );
                   fieldsMap[field.schemaName] = {
-                    type: this.getGraphQLOutputType(
-                      field.target,
-                      field.name,
-                      field.getType(),
-                      field.typeOptions,
-                    ),
+                    type,
                     args: this.generateHandlerArgs(field.target, field.name, field.params!),
                     resolve: fieldResolverMetadata
                       ? createAdvancedFieldResolver(fieldResolverMetadata)
                       : createBasicFieldResolver(field),
                     description: field.description,
                     deprecationReason: field.deprecationReason,
+                    astNode: getFieldDefinitionNode(field.name, type, field.directives),
                     extensions: {
                       complexity: field.complexity,
                       ...field.extensions,

--- a/tests/helpers/directives/assertValidDirective.ts
+++ b/tests/helpers/directives/assertValidDirective.ts
@@ -2,13 +2,19 @@ import {
   FieldDefinitionNode,
   InputObjectTypeDefinitionNode,
   InputValueDefinitionNode,
+  InterfaceTypeDefinitionNode,
   parseValue,
 } from "graphql";
 
 import { Maybe } from "../../../src/interfaces/Maybe";
 
 export function assertValidDirective(
-  astNode: Maybe<FieldDefinitionNode | InputObjectTypeDefinitionNode | InputValueDefinitionNode>,
+  astNode: Maybe<
+    | FieldDefinitionNode
+    | InputObjectTypeDefinitionNode
+    | InputValueDefinitionNode
+    | InterfaceTypeDefinitionNode
+  >,
   name: string,
   args?: { [key: string]: string },
 ): void {


### PR DESCRIPTION
This PR adds support for using `@Directive` on InterfaceType (and its fields).

Directives are supported on interface as per [GraphQL specs](https://spec.graphql.org/June2018/#sec-Interfaces) and that support is widely implemented, see [Apollo](https://github.com/graphql/graphql-js/blob/a62eea88d5844a3bd9725c0f3c30950a78727f3e/src/language/directiveLocation.js#L22-L33) for example.

### Possible caveats
In this proposed implementation, any ObjectType implementing the interface (more precisely, whose typescript class extends the typescript class of the interface) will inherit its directives. This seems in line with the current behavior of TypeGraphQL.
Nevertheless, as it stands, users would **not** be able to __only__ add directive to the interface and not the objects implementing it.

I'd love insights about this behavior and if you think that's a problem.