### PR TITLE
docs(subscriptions): Add how to integrate subscription servers without ApolloServer

### DIFF
--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -194,6 +194,31 @@ const server = new ApolloServer({
 
 And it's done! We have a working GraphQL subscription server on `/subscriptions`, along with the normal HTTP GraphQL server.
 
+If you're using servers other than `ApolloServer` (e.g. plain Fastify), you can integrate them using `subscriptions-transport-ws`:
+
+```
+import fastify from 'fastify'
+import { execute, subscribe } from 'graphql'
+import { SubscriptionServer } from 'subscriptions-transport-ws'
+
+// Create TypeGraphQL schema before initializing the app
+// const schema = buildSchema(...
+
+const app = fastify()
+
+const subscriptionServer = SubscriptionServer.create(
+  {
+    schema,
+    execute,
+    subscribe,
+  },
+  {
+    server: app.server,
+    path: '/graphql/subscriptions',
+  },
+)
+```
+
 ## Examples
 
 See how subscriptions work in a [simple example](https://github.com/MichalLytek/type-graphql/tree/master/examples/simple-subscriptions).


### PR DESCRIPTION
I think it is helpful to mention how to implement without `ApolloServer` for those who don't use it.