### PR TITLE
feat(types): use static fromModule from Target if exists

### DIFF
--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -107,7 +107,9 @@ export function convertToType(Target: any, data?: object): object | undefined {
     return data.map(item => convertToType(Target, item));
   }
 
-  return Object.assign(new Target(), data);
+  return typeof Target.fromModel === "function"
+    ? Target.fromModel(data)
+    : Object.assign(new Target(), data);
 }
 
 export function getEnumValuesMap<T extends object>(enumObject: T) {


### PR DESCRIPTION
Hi

I faced the same issue as described in https://github.com/MichalLytek/type-graphql/issues/117 but proposed solution didn't work for me because my typegoose model have subschema in it:

```typescript
@ObjectType()
export class Avatar {
  @Field(() => Int)
  @prop({ required: true })
  public height!: number;

  @Field(() => Int)
  @prop({ required: true })
  public width!: number;

  @Field()
  public get url(): string {
    return "https://...";
  }
}

@ObjectType()
export class User {
  @Field(() => Avatar, { nullable: true })
  @prop({ _id: true, type: () => Avatar, required: false })
  public avatar?: Avatar;
}
```

When `type-graphql` serializes `User` model from mongoose document (which is returned by `find` static method) it looses all properties in `avatar` because of the way how mongoose document keeps data internally (they appeared available in `this._doc` which I also saw in other issues).

So there are couple of possible solutions how to avoid this:
1. use a kind of "standard" function shortcut for getting object data via `obj.toJSON()` or `obj.toObject()` but this could lead to unwanted results in already existing projects
2. use type class method, like `fromModel` which converts real data into type, which could be smth below for mongoose:

```typescript
@ObjectType()
export class Avatar {
  @Field(() => Int)
  @prop({ required: true })
  public height!: number;

  @Field(() => Int)
  @prop({ required: true })
  public width!: number;

  @Field()
  public get url(): string {
    return "https://...";
  }

  public static fromModel(data: DocumentType<Avatar>): Avatar {
    return Object.assign(new Avatar(), data.toObject());
  }
}

```

This solution also helps me with a more complex cases as well.

@MichalLytek do you think it worth merging?
