### PR TITLE
Typo: GraphQL IPerson -> GraphQL Person

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -103,7 +103,7 @@ interface Person implements Node {
   age: Int!
 }
 
-type Student implements Node & IPerson {
+type Student implements Node & Person {
   id: ID!
   name: String!
   age: Int!


### PR DESCRIPTION
Typo.

The GraphQL interface should be Person and not IPerson.