### PR TITLE
Support for directives in emitSchemaDefinitionFile function

### DIFF
--- a/docs/directives.md
+++ b/docs/directives.md
@@ -67,6 +67,9 @@ class FooBarResolver {
 
 > Note that even as directives are a purely SDL thing, they won't appear in the generated schema definition file. Current implementation of directives in TypeGraphQL is using some crazy workarounds because [`graphql-js` doesn't support setting them by code](https://github.com/graphql/graphql-js/issues/1343) and the built-in `printSchema` utility omits the directives while printing.
 
+> If you want the directives to appear in the generated schema definition file you must set `directives` option to `true`. Be aware that emitting the schema with directives **does not use** the official `printSchema` from graphql-js but `printSchemaWithDirectives` from **@graphql-tools/utils** (https://www.graphql-tools.com/docs/api/modules/utils#printschemawithdirectives).
+> Moreover `printschemawithdirectives` it does not allow customization of printSchema options having to do with comments, so **`commentDescriptions` option is ignored**.
+
 Also please note that `@Directive` can only contain a single GraphQL directive name or declaration. If you need to have multiple directives declared, just place multiple decorators:
 
 ```typescript

--- a/docs/emit-schema.md
+++ b/docs/emit-schema.md
@@ -16,8 +16,9 @@ const schema = await buildSchema({
   // or pass a config object
   emitSchemaFile: {
     path: __dirname + "/schema.gql",
-    commentDescriptions: true,
+    commentDescriptions: true, // if 'directives' is true 'commentDescriptions' is ignored
     sortedSchema: false, // by default the printed schema is sorted alphabetically
+    directives: true, // emit the schema with directives
   },
 });
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@graphql-tools/utils": "^7.6.0",
         "@types/glob": "^7.1.3",
         "@types/node": "*",
         "@types/semver": "^7.3.4",
@@ -66,7 +67,7 @@
         "typescript": "~4.2.2"
       },
       "engines": {
-        "node": ">= 10.3"
+        "node": ">= 10.13"
       },
       "funding": {
         "type": "opencollective",
@@ -200,6 +201,22 @@
       "peerDependencies": {
         "graphql": "0.13.1 - 15"
       }
+    },
+    "node_modules/@ardatan/aggregate-error": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@ardatan/aggregate-error/-/aggregate-error-0.0.6.tgz",
+      "integrity": "sha512-vyrkEHG1jrukmzTPtyWB4NLPauUw5bQeg4uhn8f+1SSynmrOcyvlb1GKQjjgoBzElLdfXCRYX8UnBlhklOHYRQ==",
+      "dependencies": {
+        "tslib": "~2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@ardatan/aggregate-error/node_modules/tslib": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.12.11",
@@ -941,6 +958,19 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
       "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==",
       "dev": true
+    },
+    "node_modules/@graphql-tools/utils": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.6.0.tgz",
+      "integrity": "sha512-YCZDDdhfb4Yhie0IH031eGdvQG8C73apDuNg6lqBNbauNw45OG/b8wi3+vuMiDnJTJN32GQUb1Gt9gxDKoRDKw==",
+      "dependencies": {
+        "@ardatan/aggregate-error": "0.0.6",
+        "camel-case": "4.1.2",
+        "tslib": "~2.1.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0"
+      }
     },
     "node_modules/@hapi/hoek": {
       "version": "9.1.1",
@@ -3536,6 +3566,15 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "dependencies": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/camelcase": {
@@ -6312,6 +6351,7 @@
       "version": "15.5.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz",
       "integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==",
+      "dev": true,
       "engines": {
         "node": ">= 10.x"
       }
@@ -9463,6 +9503,14 @@
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
       "dev": true
     },
+    "node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -10248,6 +10296,15 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
@@ -10845,6 +10902,15 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/pascalcase": {
@@ -15176,6 +15242,21 @@
         "object-path": "^0.11.4"
       }
     },
+    "@ardatan/aggregate-error": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@ardatan/aggregate-error/-/aggregate-error-0.0.6.tgz",
+      "integrity": "sha512-vyrkEHG1jrukmzTPtyWB4NLPauUw5bQeg4uhn8f+1SSynmrOcyvlb1GKQjjgoBzElLdfXCRYX8UnBlhklOHYRQ==",
+      "requires": {
+        "tslib": "~2.0.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -15802,6 +15883,16 @@
           "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==",
           "dev": true
         }
+      }
+    },
+    "@graphql-tools/utils": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.6.0.tgz",
+      "integrity": "sha512-YCZDDdhfb4Yhie0IH031eGdvQG8C73apDuNg6lqBNbauNw45OG/b8wi3+vuMiDnJTJN32GQUb1Gt9gxDKoRDKw==",
+      "requires": {
+        "@ardatan/aggregate-error": "0.0.6",
+        "camel-case": "4.1.2",
+        "tslib": "~2.1.0"
       }
     },
     "@hapi/hoek": {
@@ -17184,8 +17275,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.4.2.tgz",
       "integrity": "sha512-FeGxW3Batn6sUtX3OVVUm7o56EgjxDlmgpTLNyWcLb0j6P8mw9oLNyAm3B+deHA4KNdNHO5BmHS2g1SJYjqPCQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "apollo-server-express": {
       "version": "2.21.0",
@@ -17926,6 +18016,15 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
+    },
+    "camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "requires": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
+      }
     },
     "camelcase": {
       "version": "5.3.1",
@@ -20161,7 +20260,8 @@
     "graphql": {
       "version": "15.5.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz",
-      "integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA=="
+      "integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==",
+      "dev": true
     },
     "graphql-extensions": {
       "version": "0.12.8",
@@ -20204,8 +20304,7 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.11.0.tgz",
       "integrity": "sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "graphql-tools": {
       "version": "4.0.8",
@@ -21669,8 +21768,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "26.0.0",
@@ -22092,8 +22190,7 @@
           "version": "7.4.3",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
           "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -22555,6 +22652,14 @@
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
       "dev": true
+    },
+    "lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "requires": {
+        "tslib": "^2.0.3"
+      }
     },
     "lru-cache": {
       "version": "5.1.1",
@@ -23057,8 +23162,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
       "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "mpath": {
       "version": "0.7.0",
@@ -23170,6 +23274,15 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "requires": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
     },
     "node-fetch": {
       "version": "2.6.1",
@@ -23625,6 +23738,15 @@
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "dev": true
     },
+    "pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -23724,8 +23846,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.2.2.tgz",
       "integrity": "sha512-ORJoFxAlmmros8igi608iVEbQNNZlp89diFVx6yV5v+ehmpMY9sK6QgpmgoXbmkNaBAx8cOOZh9g80kJv1ooyA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "pg-protocol": {
       "version": "1.4.0",
@@ -26259,8 +26380,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/typeorm-typedi-extensions/-/typeorm-typedi-extensions-0.4.1.tgz",
       "integrity": "sha512-05hWktQ4zuXzTTUO3ao56yOezlvUuZhH2NRS//m0SOGCAJoVlfPTMHcmDaMSQy/lMfAwPWoIyn+sfK7ONzTdXQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "typescript": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "graphql": "^15.5.0"
   },
   "dependencies": {
+    "@graphql-tools/utils": "^7.6.0",
     "@types/glob": "^7.1.3",
     "@types/node": "*",
     "@types/semver": "^7.3.4",


### PR DESCRIPTION
**Please, before doing anything about this pull request read my use case.**

## Use Case
Currently I'm working for a project that is based on apollo [Federation architecture](https://www.apollographql.com/docs/federation).
This implies the usage of custom directives.
In development all works without any issues and the experience is awesome (thanks!).
In production Apollo Server has the introspection property disabled and the Gateway is no longer responsible for fetching schemas from the services (directly) but using [Managed federation](https://www.apollographql.com/docs/federation/managed-federation/overview). To set up managed federation we must register all implementing service schemas providing a schema file (introspection query on the running service to fetch the schema is supported but I think is not so great expecially during CI/CD).
So we must have these schema definition files with Apollo Federation directives.
Moreover it can be really useful when using in combination with [GraphQL Inspector](https://graphql-inspector.com).

## emitSchemaDefinitionFile with directives
To solve *"the issue"* I've implemented the support of directives in the emitSchemaDefinitionFile function by simply passing ```directives: true``` option.
Emitting the schema with directives **does not use** the official `printSchema` from graphql-js but `printSchemaWithDirectives` from **@graphql-tools/utils** (https://www.graphql-tools.com/docs/api/modules/utils#printschemawithdirectives).
The *"only"* drawback (as far as I know) of using ```printschemawithdirectives``` is that it does not allow customization of printSchema options having to do with comments, so **`commentDescriptions` option is ignored**.

## Example
```typescript
import { emitSchemaDefinitionFile, buildSchema } from "type-graphql";

const schema = await buildSchema(...);

await emitSchemaDefinitionFile("./schema.graphql", schema, { directives: true });
```

In the future if ```graph-js``` will support directives in the *printSchema* function the ```directives``` option can be easily deprecated.
Or, if also *printSchema* require a flag this flag can be easily ported.

PS: This flag is false by default.