### PR TITLE
fix(resolvers): make orphanedTypes to be set as intended in `generateFromMetadata`

### DIFF
--- a/src/helpers/loadResolversFromGlob.ts
+++ b/src/helpers/loadResolversFromGlob.ts
@@ -6,5 +6,10 @@ export function findFileNamesFromGlob(globString: string) {
 
 export function loadResolversFromGlob(globString: string) {
   const filePaths = findFileNamesFromGlob(globString);
-  const modules = filePaths.map(fileName => require(fileName));
+  const modules = filePaths.reduce(
+    (merged, fileName) => [...merged, ...Object.values(require(fileName) as Function[])],
+    [] as Function[],
+  );
+
+  return modules;
 }

--- a/src/utils/buildSchema.ts
+++ b/src/utils/buildSchema.ts
@@ -52,12 +52,17 @@ function loadResolvers(options: BuildSchemaOptions): Function[] | undefined {
     throw new Error("Empty `resolvers` array property found in `buildSchema` options!");
   }
   if (options.resolvers.some((resolver: Function | string) => typeof resolver === "string")) {
+    const resolvers: Function[] = [];
+
     (options.resolvers as string[]).forEach(resolver => {
       if (typeof resolver === "string") {
-        loadResolversFromGlob(resolver);
+        resolvers.push(...loadResolversFromGlob(resolver));
+      } else {
+        resolvers.push(resolver);
       }
     });
-    return undefined;
+
+    return resolvers;
   }
   return options.resolvers as Function[];
 }

--- a/tests/helpers/loading-from-directories/sample.type.ts
+++ b/tests/helpers/loading-from-directories/sample.type.ts
@@ -5,3 +5,9 @@ export class SampleObject {
   @Field()
   sampleField: string;
 }
+
+@ObjectType()
+export class SampleObject2 {
+  @Field()
+  sampleField: string;
+}


### PR DESCRIPTION
## Problem

Object types that are not directly used in other types definition should not emitted in schema - except for that implements an interface with auto registering.
However, when we build schema with _glob path_ in the `resolvers` option, all orphaned types will be emitted to schema.

```typescript
const graphqlSchemaFromTypeGraphql = buildSchemaSync({
  resolvers: [`${__dirname}/**/*.resolver.js`],
  dateScalarMode: 'isoDate',
  scalarsMap: [{ type: Date, scalar: GraphQLISODateTime }],
  container: ({ context }: ResolverData<Context>) => Container.of(context.requestId),
  authChecker,
});
```

## What's the matter?

We emit isolated types to schema only if it is included in the `orphanedTypes` option.

https://github.com/MichalLytek/type-graphql/blob/aa0c7bb3f6b8fa4861456d96d41313d74af8cf1f/src/schema/schema-generator.ts#L872-L880

`orphanedTypes` is set to `[]` when we call `buildSchema` or `buildSchemaSync` with `resolvers` option.

https://github.com/MichalLytek/type-graphql/blob/aa0c7bb3f6b8fa4861456d96d41313d74af8cf1f/src/schema/schema-generator.ts#L125-L131

If glob pattern is passed to `resolvers` when calling `buildSchema` or `buildSchemaSync`, `options.resolvers` in `generateFromMetadata` is set to `undefined`.

https://github.com/MichalLytek/type-graphql/blob/aa0c7bb3f6b8fa4861456d96d41313d74af8cf1f/src/utils/buildSchema.ts#L49-L63

## Solution

Make `loadResolvers` to always return a list of resolvers.