### PR TITLE
Support readonly arrays for roles of Authorized decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - allow defining directives for interface types and theirs fields, with inheritance for object types fields (#744)
 - allow deprecating input fields and args (#794)
 - support disabling inferring default values (#793)
+- support readonly arrays for roles of `@Authorized` decorator (#935)
 ### Fixes
 - **Breaking Change**: properly emit types nullability when `defaultValue` is provided and remove `ConflictingDefaultWithNullableError` error (#751)
 - allow defining extension on field resolver level for fields also defined as a property of the class (#776)

--- a/src/decorators/Authorized.ts
+++ b/src/decorators/Authorized.ts
@@ -5,7 +5,9 @@ import { MethodAndPropDecorator } from "./types";
 
 export function Authorized(): MethodAndPropDecorator;
 export function Authorized<RoleType = string>(roles: readonly RoleType[]): MethodAndPropDecorator;
-export function Authorized<RoleType = string>(...roles: readonly RoleType[]): MethodAndPropDecorator;
+export function Authorized<RoleType = string>(
+  ...roles: readonly RoleType[]
+): MethodAndPropDecorator;
 export function Authorized<RoleType = string>(
   ...rolesOrRolesArray: Array<RoleType | readonly RoleType[]>
 ): MethodDecorator | PropertyDecorator {

--- a/src/decorators/Authorized.ts
+++ b/src/decorators/Authorized.ts
@@ -4,10 +4,10 @@ import { getArrayFromOverloadedRest } from "../helpers/decorators";
 import { MethodAndPropDecorator } from "./types";
 
 export function Authorized(): MethodAndPropDecorator;
-export function Authorized<RoleType = string>(roles: RoleType[]): MethodAndPropDecorator;
-export function Authorized<RoleType = string>(...roles: RoleType[]): MethodAndPropDecorator;
+export function Authorized<RoleType = string>(roles: readonly RoleType[]): MethodAndPropDecorator;
+export function Authorized<RoleType = string>(...roles: readonly RoleType[]): MethodAndPropDecorator;
 export function Authorized<RoleType = string>(
-  ...rolesOrRolesArray: Array<RoleType | RoleType[]>
+  ...rolesOrRolesArray: Array<RoleType | readonly RoleType[]>
 ): MethodDecorator | PropertyDecorator {
   const roles = getArrayFromOverloadedRest(rolesOrRolesArray);
 

--- a/src/helpers/decorators.ts
+++ b/src/helpers/decorators.ts
@@ -36,7 +36,7 @@ export function getNameDecoratorParams<T extends DescriptionOptions>(
   }
 }
 
-export function getArrayFromOverloadedRest<T>(overloadedArray: Array<T | T[]>): T[] {
+export function getArrayFromOverloadedRest<T>(overloadedArray: Array<T | readonly T[]>): T[] {
   let items: T[];
   if (Array.isArray(overloadedArray[0])) {
     items = overloadedArray[0] as T[];

--- a/tests/functional/authorization.ts
+++ b/tests/functional/authorization.ts
@@ -185,8 +185,7 @@ describe("Authorization", () => {
     });
 
     // TODO: check for wrong `@Authorized` usage
-    // it("should throw error when `@Authorized` is used on args, input or interface class", async () => {
-    // }
+    it.todo("should throw error when `@Authorized` is used on args, input or interface class");
   });
 
   describe("Functional", () => {
@@ -539,6 +538,35 @@ describe("Authorization", () => {
       expect(authCheckerResolverData.args).toEqual({});
       expect(authCheckerResolverData.info).toBeDefined();
       expect(authCheckerRoles).toEqual(["ADMIN", "REGULAR"]);
+    });
+  });
+
+  describe("with constant readonly array or roles", () => {
+    let testResolver: Function;
+
+    beforeAll(() => {
+      getMetadataStorage().clear();
+
+      const CONSTANT_ROLES = ["a", "b", "c"] as const;
+
+      @Resolver()
+      class TestResolver {
+        @Query()
+        @Authorized(CONSTANT_ROLES)
+        authedQuery(@Ctx() ctx: any): boolean {
+          return ctx.user !== undefined;
+        }
+      }
+
+      testResolver = TestResolver;
+    });
+
+    it("should not throw an error", async () => {
+      await buildSchema({
+        resolvers: [testResolver],
+        // dummy auth checker
+        authChecker: () => false,
+      });
     });
   });
 });


### PR DESCRIPTION
The `@Authorized` decorator specifies `roles: T[]` or `...roles: T[]` as its argument. 

We have a constant sets of roles:

```ts
export const ADMIN_ROLES = ['a', 'b', 'c'] as const;
export const AdminRole = typeof ADMIN_ROLES[number];
```

We would like to use:

```ts
@Authorized<AdminRole>(ADMIN_ROLES);
```

TypeScript doesn't allow this because `readonly` arrays cannot be used in places where a non-`readonly` array is specified. However, a normal `Array` _can_ be used anywhere a `readonly Array<T>` is specified.

For now our workaround is spreading our constant array when used.

```ts
@Authorized(...ADMIN_ROLES);
```

