### PR TITLE
feat: Allow async subscription handlers

### DIFF
--- a/src/decorators/Subscription.ts
+++ b/src/decorators/Subscription.ts
@@ -1,5 +1,3 @@
-import { ResolverFn } from "graphql-subscriptions";
-
 import {
   ReturnTypeFunc,
   AdvancedOptions,
@@ -16,6 +14,13 @@ interface PubSubOptions {
   topics: string | string[] | SubscriptionTopicFunc;
   filter?: SubscriptionFilterFunc;
 }
+
+export type ResolverFn = (
+  rootValue?: any,
+  args?: any,
+  context?: any,
+  info?: any,
+) => AsyncIterator<any> | Promise<AsyncIterator<any>>;
 
 interface SubscribeOptions {
   subscribe: ResolverFn;

--- a/src/metadata/definitions/resolver-metadata.ts
+++ b/src/metadata/definitions/resolver-metadata.ts
@@ -1,5 +1,3 @@
-import { ResolverFn } from "graphql-subscriptions";
-
 import {
   TypeValueThunk,
   TypeOptions,
@@ -12,6 +10,7 @@ import { Middleware } from "../../interfaces/Middleware";
 import { Complexity } from "../../interfaces";
 import { DirectiveMetadata } from "./directive-metadata";
 import { ExtensionsMetadata } from "./extensions-metadata";
+import { ResolverFn } from "../../decorators/Subscription";
 
 export interface BaseResolverMetadata {
   methodName: string;


### PR DESCRIPTION
I understand (and appreciate) that no breaking changes should be introduced into v1, as you've explained to me in #470. I just wanted to propose an actual change so you can assess what I'm suggesting.

I don't see this change conflicting with any existing subscription code, regardless of if `graphql-subscriptions` or a drop-in-replacement is being used.

The existing `ResolverFn` type from `graphql-subscriptions` is only relevant in their `withFilter` utility, which is not impacted by this change and continues to behave exactly as advertised.

Enabling async subscription handling would open up a lot of use cases in validating a subscription request, which currently has to be deferred into the handling of events in the subscription (like through the async filter method when using `withFilter`) when the subscription was already accepted.

Fixes #470