### PR TITLE
feat(resolvers): add mapped types for resolver interface

### DIFF
--- a/src/interfaces/ResolverInterface.ts
+++ b/src/interfaces/ResolverInterface.ts
@@ -1,7 +1,15 @@
+export const MappedType = Symbol("MappedType");
+
+export type Mapped<T> = T extends { [MappedType]: infer M }
+  ? M
+  : T extends Array<{ [MappedType]: infer N }>
+  ? N[]
+  : T;
+
 /**
  * Resolver classes can implement this type
  * to provide a proper resolver method signatures for fields of T.
  */
 export type ResolverInterface<T extends object> = {
-  [P in keyof T]?: (root: T, ...args: any[]) => T[P] | Promise<T[P]>;
+  [P in keyof T]?: (root: Mapped<T>, ...args: any[]) => Mapped<T[P]> | Promise<Mapped<T[P]>>;
 };


### PR DESCRIPTION
This adds the ability to map Apollo types to internal application types and have the resolver interface map the types accordingly for all field resolvers.

So a type mapped like this:

```
      @ObjectType()
      class SampleChildObject {
        [MappedType]: SurrogateObject;

        @Field()
        normalField: string;
      }
```
Makes the resolver interface get the root typed like this: 

```
      @Resolver(of => SampleChildObject)
      class SampleChildResolver implements ResolverInterface<SampleChildObject> {
        @FieldResolver()
        normalField(@Root() root: SurrogateObject) {
          return root.hiddenField;
        }
      }
```

This is backwards compatible, so a type with no mapping defined defaults to the original type.