### PR TITLE
Set class-validator as an optional dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
     "postinstall": "node ./dist/postinstall || exit 0"
   },
   "peerDependencies": {
-    "class-validator": ">=0.12.0",
     "graphql": "^15.5.0"
+  },
+  "optionalDependencies": {
+    "class-validator": ">=0.12.0",
   },
   "dependencies": {
     "@types/glob": "^7.1.3",


### PR DESCRIPTION
Hello,

I just want to open a debate to set class-validator as an optional dependencies.

I personally use something else for extra validation and without class-validator it seam to be working.

I guess, this small PR isn't enough (the documentation is missing, we should update .lock, make sure it's optional everywhere in the code, ...).


