### PR TITLE
docs(getting-started): Add commas so around "of course" it reads corr…

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -108,7 +108,7 @@ The detailed rules for when and why we declare `returns => Recipe` functions and
 
 ## Inputs and Arguments
 
-Ok, but what are `NewRecipeInput` and `RecipesArgs`? They are of course classes:
+Ok, but what are `NewRecipeInput` and `RecipesArgs`? They are, of course, classes:
 
 ```typescript
 @InputType()

--- a/website/versioned_docs/version-0.16.0/getting-started.md
+++ b/website/versioned_docs/version-0.16.0/getting-started.md
@@ -9,7 +9,9 @@ To explore all powerful capabilities of TypeGraphQL, we will create a sample Gra
 Let's start with the `Recipe` type, which is the foundations of our API.
 
 ## Types
+
 We want to get equivalent of this type described in SDL:
+
 ```graphql
 type Recipe {
   id: ID!
@@ -21,6 +23,7 @@ type Recipe {
 ```
 
 So we create the `Recipe` class with all properties and types:
+
 ```typescript
 class Recipe {
   id: string;
@@ -32,6 +35,7 @@ class Recipe {
 ```
 
 Then we decorate the class and its properties with decorators:
+
 ```typescript
 @ObjectType()
 class Recipe {
@@ -51,6 +55,7 @@ class Recipe {
   ingredients: string[];
 }
 ```
+
 The detailed rules when to use `nullable`, `array` and others are described in [fields and types docs](types-and-fields.md).
 
 ## Resolvers
@@ -103,7 +108,8 @@ The detailed rules when and why we declare `returns => Recipe` functions and oth
 
 ## Inputs and arguments
 
-Ok, but what are `NewRecipeInput` and `RecipesArgs`? They are of course classes:
+Ok, but what are `NewRecipeInput` and `RecipesArgs`? They are, of course, classes:
+
 ```typescript
 @InputType()
 class NewRecipeDataInput {
@@ -127,18 +133,21 @@ class RecipesArgs {
   skip: number = 0;
 
   @Field(type => Int)
-  @Min(1) @Max(50)
+  @Min(1)
+  @Max(50)
   take: number = 25;
 }
-
 ```
+
 `@Length`, `@Min` or `@MaxArraySize` are decorators from [`class-validator`](https://github.com/typestack/class-validator) that automatically perform fields validation in TypeGraphQL.
 
 ## Building schema
+
 The last step that we have to do is to actually build the schema from TypeGraphQL definition. We use `buildSchema` function for this:
+
 ```typescript
 const schema = await buildSchema({
-  resolvers: [RecipeResolver]
+  resolvers: [RecipeResolver],
 });
 
 // ...creating express server or sth
@@ -146,6 +155,7 @@ const schema = await buildSchema({
 
 Et voilà! Now we have fully working GraphQL schema!
 If we print it, we would receive exactly this:
+
 ```graphql
 type Recipe {
   id: ID!
@@ -170,6 +180,7 @@ type Mutation {
 ```
 
 ## Want more?
+
 That was only a tip of the iceberg - a very simple example with basic GraphQL types. Do you use interfaces, enums, unions and custom scalars? That's great because TypeGraphQL fully supports them too! There are also more advanced concepts like authorization checker, inheritance support or field resolvers.
 
-If you want to see how it looks in more complicated case, you can go to the [Examples section](examples.md) where you can find e.g. how nice TypeGraphQL integrates with TypeORM. 
+If you want to see how it looks in more complicated case, you can go to the [Examples section](examples.md) where you can find e.g. how nice TypeGraphQL integrates with TypeORM.

--- a/website/versioned_docs/version-0.17.0/getting-started.md
+++ b/website/versioned_docs/version-0.17.0/getting-started.md
@@ -110,7 +110,7 @@ The detailed rules when and why we declare `returns => Recipe` functions and oth
 
 ## Inputs and arguments
 
-Ok, but what are `NewRecipeInput` and `RecipesArgs`? They are of course classes:
+Ok, but what are `NewRecipeInput` and `RecipesArgs`? They are, of course, classes:
 
 ```typescript
 @InputType()

--- a/website/versioned_docs/version-0.17.1/getting-started.md
+++ b/website/versioned_docs/version-0.17.1/getting-started.md
@@ -110,7 +110,7 @@ The detailed rules for when and why we declare `returns => Recipe` functions and
 
 ## Inputs and Arguments
 
-Ok, but what are `NewRecipeInput` and `RecipesArgs`? They are of course classes:
+Ok, but what are `NewRecipeInput` and `RecipesArgs`? They are, of course, classes:
 
 ```typescript
 @InputType()

--- a/website/versioned_docs/version-0.17.2/getting-started.md
+++ b/website/versioned_docs/version-0.17.2/getting-started.md
@@ -110,7 +110,7 @@ The detailed rules for when and why we declare `returns => Recipe` functions and
 
 ## Inputs and Arguments
 
-Ok, but what are `NewRecipeInput` and `RecipesArgs`? They are of course classes:
+Ok, but what are `NewRecipeInput` and `RecipesArgs`? They are, of course, classes:
 
 ```typescript
 @InputType()

--- a/website/versioned_docs/version-1.0.0/getting-started.md
+++ b/website/versioned_docs/version-1.0.0/getting-started.md
@@ -110,7 +110,7 @@ The detailed rules for when and why we declare `returns => Recipe` functions and
 
 ## Inputs and Arguments
 
-Ok, but what are `NewRecipeInput` and `RecipesArgs`? They are of course classes:
+Ok, but what are `NewRecipeInput` and `RecipesArgs`? They are, of course, classes:
 
 ```typescript
 @InputType()


### PR DESCRIPTION
The sentence `They are of course classes:` requires commas on either side for "of course" in order for it to read naturally and be grammatically correct.  `They are, of course, classes:`

Another option that may be more common would be `They are classes, of course:` I think this one would be the most natural but this is a matter of style.

https://english.stackexchange.com/questions/348666/comma-usage-with-of-course