### PR TITLE
fix: use schemaName instead of methodName when building field resolve…

### DIFF
--- a/src/metadata/metadata-storage.ts
+++ b/src/metadata/metadata-storage.ts
@@ -291,7 +291,9 @@ export class MetadataStorage {
           );
         }
 
-        const typeField = typeMetadata.fields!.find(fieldDef => fieldDef.name === def.methodName)!;
+        const typeField = typeMetadata.fields!.find(
+          fieldDef => fieldDef.schemaName === def.schemaName,
+        )!;
         if (!typeField) {
           const shouldCollectFieldMetadata =
             !options.resolvers ||

--- a/tests/functional/resolvers.ts
+++ b/tests/functional/resolvers.ts
@@ -2479,5 +2479,70 @@ describe("Resolvers", () => {
 
       expect(self).toBeInstanceOf(childResolver);
     });
+
+    it("should allow duplicate fieldResolver methods with different schema names for inherited resolvers", async () => {
+      getMetadataStorage().clear();
+      const INHERITED_DYNAMIC_FIELD_NAME_1 = "dynamicallyNamedMethod1";
+      const INHERITED_DYNAMIC_FIELD_NAME_2 = "dynamicallyNamedMethod2";
+
+      const withDynamicallyNamedFieldResolver = (
+        classType: ClassType,
+        BaseResolverClass: ClassType,
+        name: string,
+      ) => {
+        @Resolver(() => classType)
+        class DynamicallyNamedFieldResolver extends BaseResolverClass {
+          @FieldResolver({ name })
+          dynamicallyNamedField(): boolean {
+            return true;
+          }
+        }
+        return DynamicallyNamedFieldResolver;
+      };
+
+      @ObjectType()
+      class SampleObject {
+        @Field()
+        sampleField: string;
+      }
+
+      @Resolver()
+      class SampleResolver {
+        @Query(() => SampleObject)
+        sampleObject(): SampleObject {
+          return { sampleField: "sampleText" };
+        }
+      }
+
+      const DynamicallyNamedFieldResolver1 = withDynamicallyNamedFieldResolver(
+        SampleObject,
+        SampleResolver,
+        INHERITED_DYNAMIC_FIELD_NAME_1,
+      );
+      const DynamicallyNamedFieldResolver2 = withDynamicallyNamedFieldResolver(
+        SampleObject,
+        DynamicallyNamedFieldResolver1,
+        INHERITED_DYNAMIC_FIELD_NAME_2,
+      );
+
+      const schemaInfo = await getSchemaInfo({
+        resolvers: [DynamicallyNamedFieldResolver2],
+      });
+      schemaIntrospection = schemaInfo.schemaIntrospection;
+      const sampleObjectType = schemaIntrospection.types.find(
+        type => type.name === "SampleObject",
+      ) as IntrospectionObjectType;
+
+      const dynamicField1 = sampleObjectType.fields.find(
+        field => field.name === INHERITED_DYNAMIC_FIELD_NAME_1,
+      )!;
+
+      const dynamicField2 = sampleObjectType.fields.find(
+        field => field.name === INHERITED_DYNAMIC_FIELD_NAME_2,
+      )!;
+
+      expect(dynamicField1).toBeDefined();
+      expect(dynamicField2).toBeDefined();
+    });
   });
 });

--- a/tests/functional/resolvers.ts
+++ b/tests/functional/resolvers.ts
@@ -2503,7 +2503,7 @@ describe("Resolvers", () => {
       @ObjectType()
       class SampleObject {
         @Field()
-        sampleField: string;
+        sampleField!: string;
       }
 
       @Resolver()


### PR DESCRIPTION
Hi! 👋 
      
Firstly, thanks for your work on this project! 🙂

We are doing something more complicated, but I tried to boil it down to the essence of the issue below. Basically we have a mixin that adds very similar functionality that is parameterized by an argument `name`. We overwrite the `schemaName` appropriately by passing `name` to the field resolver, but when building the field resolver metadata, TypeGraphQL thinks that the subsequent field resolvers have already been added because it checks against the definition's `methodName`. I've run the test suite against the proposed change below, 

Simplified breaking code:
```
const withMixin = <TObjectType extends ClassType<{ id: string }>>(
  ObjectType: TObjectType,
  BaseClass: ClassType,
  name: string
) => {
  @Resolver(() => ObjectType)
  class FoobarResolver extends BaseClass {
    @FieldResolver(() => String, { name })
    async foobar(
      @Arg(`${name}Id`, () => ID) foobarId: string
    ): Promise<any> {
       ...Common logic we want to add via the mixin that is parameterized by `name`...
    }
  }
  return FoobarResolver;
};
