### PR TITLE
fix(resolvers): resolve #1142 name issue and add relevant tests

### DIFF
--- a/src/utils/createResolversMap.ts
+++ b/src/utils/createResolversMap.ts
@@ -50,7 +50,7 @@ function generateFieldsResolvers(fields: GraphQLFieldMap<any, any>): ResolverObj
 export function createResolversMap(schema: GraphQLSchema): ResolversMap {
   const typeMap = schema.getTypeMap();
   return Object.keys(typeMap)
-    .filter(typeName => !typeName.includes("__"))
+    .filter(typeName => !typeName.startsWith("__"))
     .reduce<ResolversMap>((resolversMap, typeName) => {
       const type = typeMap[typeName];
       if (type instanceof GraphQLObjectType) {


### PR DESCRIPTION
This PR fixes the issue mentioned [here](https://github.com/MichalLytek/type-graphql/issues/1142) with tests as mentioned [here](https://github.com/MichalLytek/type-graphql/issues/1142#issuecomment-997357073).
The tests successfully fail when the `startsWith` is replaced back with `includes`.

(Edit: The second 'here' is supposed to link to the last comment of the mentioned issue but it's not scrolling.)