### PR TITLE
Feat: add support for graphql@16.x.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@types/semver": "^7.3.4",
         "glob": "^7.1.6",
         "graphql-query-complexity": "^0.7.2",
-        "graphql-subscriptions": "^1.2.0",
+        "graphql-subscriptions": "^2.0.0",
         "semver": "^7.3.4",
         "tslib": "^2.1.0"
       },
@@ -38,7 +38,7 @@
         "apollo-server-plugin-response-cache": "^0.6.0",
         "class-validator": "^0.13.1",
         "del": "^6.0.0",
-        "graphql": "^15.5.0",
+        "graphql": "^16.6.0",
         "graphql-redis-subscriptions": "^2.3.1",
         "graphql-tag": "^2.11.0",
         "gulp-replace": "^1.0.0",
@@ -66,15 +66,11 @@
         "typescript": "~4.2.2"
       },
       "engines": {
-        "node": ">= 10.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typegraphql"
+        "node": ">= 10.13"
       },
       "peerDependencies": {
         "class-validator": ">=0.12.0",
-        "graphql": "^15.5.0"
+        "graphql": ">=15.5.0"
       }
     },
     "node_modules/@apollo/federation": {
@@ -2617,6 +2613,18 @@
         "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
       }
     },
+    "node_modules/apollo-server-express/node_modules/graphql-subscriptions": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-1.2.1.tgz",
+      "integrity": "sha512-95yD/tKi24q8xYa7Q9rhQN16AYj5wPbrb8tmHGM3WRc9EBmWrG/0kkMl+tQG8wcEuE9ibR4zyOM31p5Sdr2v4g==",
+      "dev": true,
+      "dependencies": {
+        "iterall": "^1.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.10.5 || ^0.11.3 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+      }
+    },
     "node_modules/apollo-server-plugin-base": {
       "version": "0.10.4",
       "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.10.4.tgz",
@@ -2664,6 +2672,18 @@
       },
       "peerDependencies": {
         "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/apollo-server/node_modules/graphql-subscriptions": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-1.2.1.tgz",
+      "integrity": "sha512-95yD/tKi24q8xYa7Q9rhQN16AYj5wPbrb8tmHGM3WRc9EBmWrG/0kkMl+tQG8wcEuE9ibR4zyOM31p5Sdr2v4g==",
+      "dev": true,
+      "dependencies": {
+        "iterall": "^1.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.10.5 || ^0.11.3 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/apollo-tracing": {
@@ -6309,11 +6329,12 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz",
-      "integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==",
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
+      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
+      "dev": true,
       "engines": {
-        "node": ">= 10.x"
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
     "node_modules/graphql-extensions": {
@@ -6360,14 +6381,14 @@
       }
     },
     "node_modules/graphql-subscriptions": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-1.2.0.tgz",
-      "integrity": "sha512-uXvp729fztqwa7HFUFaAqKwNMwwOfsvu4HwOu7/35Cd44bNrMPCn97mNGN0ybuuZE36CPXBTaW/4U/xyOS4D9w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-2.0.0.tgz",
+      "integrity": "sha512-s6k2b8mmt9gF9pEfkxsaO1lTxaySfKoEJzEfmwguBbQ//Oq23hIXCfR1hm4kdh5hnR20RdwB+s3BCb+0duHSZA==",
       "dependencies": {
         "iterall": "^1.3.0"
       },
       "peerDependencies": {
-        "graphql": "^0.10.5 || ^0.11.3 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+        "graphql": "^15.7.2 || ^16.0.0"
       }
     },
     "node_modules/graphql-tag": {
@@ -17092,6 +17113,17 @@
         "graphql-subscriptions": "^1.0.0",
         "graphql-tools": "^4.0.8",
         "stoppable": "^1.1.0"
+      },
+      "dependencies": {
+        "graphql-subscriptions": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-1.2.1.tgz",
+          "integrity": "sha512-95yD/tKi24q8xYa7Q9rhQN16AYj5wPbrb8tmHGM3WRc9EBmWrG/0kkMl+tQG8wcEuE9ibR4zyOM31p5Sdr2v4g==",
+          "dev": true,
+          "requires": {
+            "iterall": "^1.3.0"
+          }
+        }
       }
     },
     "apollo-server-caching": {
@@ -17184,8 +17216,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.4.2.tgz",
       "integrity": "sha512-FeGxW3Batn6sUtX3OVVUm7o56EgjxDlmgpTLNyWcLb0j6P8mw9oLNyAm3B+deHA4KNdNHO5BmHS2g1SJYjqPCQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "apollo-server-express": {
       "version": "2.21.0",
@@ -17210,6 +17241,17 @@
         "parseurl": "^1.3.2",
         "subscriptions-transport-ws": "^0.9.16",
         "type-is": "^1.6.16"
+      },
+      "dependencies": {
+        "graphql-subscriptions": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-1.2.1.tgz",
+          "integrity": "sha512-95yD/tKi24q8xYa7Q9rhQN16AYj5wPbrb8tmHGM3WRc9EBmWrG/0kkMl+tQG8wcEuE9ibR4zyOM31p5Sdr2v4g==",
+          "dev": true,
+          "requires": {
+            "iterall": "^1.3.0"
+          }
+        }
       }
     },
     "apollo-server-plugin-base": {
@@ -20159,9 +20201,10 @@
       "dev": true
     },
     "graphql": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz",
-      "integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA=="
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
+      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
+      "dev": true
     },
     "graphql-extensions": {
       "version": "0.12.8",
@@ -20193,9 +20236,9 @@
       }
     },
     "graphql-subscriptions": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-1.2.0.tgz",
-      "integrity": "sha512-uXvp729fztqwa7HFUFaAqKwNMwwOfsvu4HwOu7/35Cd44bNrMPCn97mNGN0ybuuZE36CPXBTaW/4U/xyOS4D9w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-2.0.0.tgz",
+      "integrity": "sha512-s6k2b8mmt9gF9pEfkxsaO1lTxaySfKoEJzEfmwguBbQ//Oq23hIXCfR1hm4kdh5hnR20RdwB+s3BCb+0duHSZA==",
       "requires": {
         "iterall": "^1.3.0"
       }
@@ -20204,8 +20247,7 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.11.0.tgz",
       "integrity": "sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "graphql-tools": {
       "version": "4.0.8",
@@ -21669,8 +21711,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "26.0.0",
@@ -22092,8 +22133,7 @@
           "version": "7.4.3",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
           "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -23057,8 +23097,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
       "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "mpath": {
       "version": "0.7.0",
@@ -23724,8 +23763,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.2.2.tgz",
       "integrity": "sha512-ORJoFxAlmmros8igi608iVEbQNNZlp89diFVx6yV5v+ehmpMY9sK6QgpmgoXbmkNaBAx8cOOZh9g80kJv1ooyA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "pg-protocol": {
       "version": "1.4.0",
@@ -26259,8 +26297,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/typeorm-typedi-extensions/-/typeorm-typedi-extensions-0.4.1.tgz",
       "integrity": "sha512-05hWktQ4zuXzTTUO3ao56yOezlvUuZhH2NRS//m0SOGCAJoVlfPTMHcmDaMSQy/lMfAwPWoIyn+sfK7ONzTdXQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "typescript": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "peerDependencies": {
     "class-validator": ">=0.12.0",
-    "graphql": "^15.5.0"
+    "graphql": ">=15.5.0"
   },
   "dependencies": {
     "@types/glob": "^7.1.3",
@@ -28,7 +28,7 @@
     "@types/semver": "^7.3.4",
     "glob": "^7.1.6",
     "graphql-query-complexity": "^0.7.2",
-    "graphql-subscriptions": "^1.2.0",
+    "graphql-subscriptions": "^2.0.0",
     "semver": "^7.3.4",
     "tslib": "^2.1.0"
   },
@@ -52,7 +52,7 @@
     "apollo-server-plugin-response-cache": "^0.6.0",
     "class-validator": "^0.13.1",
     "del": "^6.0.0",
-    "graphql": "^15.5.0",
+    "graphql": "^16.6.0",
     "graphql-redis-subscriptions": "^2.3.1",
     "graphql-tag": "^2.11.0",
     "gulp-replace": "^1.0.0",

--- a/src/schema/schema-generator.ts
+++ b/src/schema/schema-generator.ts
@@ -114,7 +114,11 @@ export abstract class SchemaGenerator {
   static async generateFromMetadata(options: SchemaGeneratorOptions): Promise<GraphQLSchema> {
     const schema = this.generateFromMetadataSync(options);
     if (!options.skipCheck) {
-      const { errors } = await graphql(schema, getIntrospectionQuery());
+      const { errors } = await graphql({
+        schema,
+        source: getIntrospectionQuery(),
+      });
+
       if (errors) {
         throw new GeneratingSchemaError(errors);
       }
@@ -855,7 +859,7 @@ export abstract class SchemaGenerator {
     return async (...args) => {
       const resolvedType = await resolveType(...args);
       if (!resolvedType || typeof resolvedType === "string") {
-        return resolvedType;
+        return resolvedType || undefined;
       }
       return possibleObjectTypesInfo.find(objectType => objectType.target === resolvedType)?.type
         .name;

--- a/src/utils/emitSchemaDefinitionFile.ts
+++ b/src/utils/emitSchemaDefinitionFile.ts
@@ -1,14 +1,12 @@
-import { GraphQLSchema, printSchema, lexicographicSortSchema } from "graphql";
-import { Options as GraphQLPrintSchemaOptions } from "graphql/utilities/printSchema";
+import { GraphQLSchema, printSchema, lexicographicSortSchema, buildClientSchema } from "graphql";
 
 import { outputFile, outputFileSync } from "../helpers/filesystem";
 
-export interface PrintSchemaOptions extends Required<GraphQLPrintSchemaOptions> {
+export interface PrintSchemaOptions {
   sortedSchema: boolean;
 }
 
 export const defaultPrintSchemaOptions: PrintSchemaOptions = {
-  commentDescriptions: false,
   sortedSchema: true,
 };
 
@@ -40,5 +38,5 @@ export async function emitSchemaDefinitionFile(
 
 function getSchemaFileContent(schema: GraphQLSchema, options: PrintSchemaOptions) {
   const schemaToEmit = options.sortedSchema ? lexicographicSortSchema(schema) : schema;
-  return generatedSchemaWarning + printSchema(schemaToEmit, options);
+  return generatedSchemaWarning + printSchema(schemaToEmit);
 }

--- a/tests/functional/authorization.ts
+++ b/tests/functional/authorization.ts
@@ -1,5 +1,5 @@
 import "reflect-metadata";
-import { GraphQLSchema, graphql } from "graphql";
+import { GraphQLSchema, graphql, ExecutionResult } from "graphql";
 
 import { getMetadataStorage } from "../../src/metadata/getMetadataStorage";
 import {
@@ -202,8 +202,7 @@ describe("Authorization", () => {
       const query = `query {
         normalQuery
       }`;
-
-      const result = await graphql(schema, query);
+      const result: ExecutionResult<any> = await graphql({ schema, source: query });
 
       expect(result.data!.normalQuery).toEqual(true);
     });
@@ -215,7 +214,7 @@ describe("Authorization", () => {
         }
       }`;
 
-      const result = await graphql(schema, query);
+      const result: ExecutionResult<any> = await graphql({ schema, source: query });
 
       expect(result.data!.normalObjectQuery.normalField).toEqual("normalField");
     });
@@ -227,7 +226,7 @@ describe("Authorization", () => {
         }
       }`;
 
-      const result = await graphql(schema, query);
+      const result: ExecutionResult<any> = await graphql({ schema, source: query });
 
       expect(result.data!.normalObjectQuery.normalResolvedField).toEqual("normalResolvedField");
     });
@@ -241,7 +240,11 @@ describe("Authorization", () => {
         authedQuery
       }`;
 
-      const result = await graphql(localSchema, query);
+      const result: ExecutionResult<any> = await graphql({
+        schema,
+        source: query,
+        contextValue: {},
+      });
 
       expect(result.data).toBeNull();
       expect(result.errors).toBeDefined();
@@ -257,7 +260,7 @@ describe("Authorization", () => {
         nullableAuthedQuery
       }`;
 
-      const result = await graphql(localSchema, query);
+      const result = await graphql({ schema: localSchema, source: query });
 
       expect(result.data!.nullableAuthedQuery).toBeNull();
       expect(result.errors).toBeUndefined();
@@ -272,7 +275,7 @@ describe("Authorization", () => {
         authedQuery
       }`;
 
-      const result = await graphql(localSchema, query);
+      const result = await graphql({ schema: localSchema, source: query });
 
       expect(result.data).toBeNull();
       expect(result.errors).toHaveLength(1);
@@ -290,7 +293,11 @@ describe("Authorization", () => {
         adminQuery
       }`;
 
-      const result = await graphql(localSchema, query);
+      const result: ExecutionResult<any> = await graphql({
+        schema,
+        source: query,
+        contextValue: {},
+      });
 
       expect(result.data).toBeNull();
       expect(result.errors).toHaveLength(1);
@@ -308,7 +315,11 @@ describe("Authorization", () => {
         authedQuery
       }`;
 
-      const result = await graphql(localSchema, query, null, {});
+      const result: ExecutionResult<any> = await graphql({
+        schema: localSchema,
+        source: query,
+        contextValue: {},
+      });
 
       expect(result.data!.authedQuery).toEqual(false);
     });
@@ -324,7 +335,11 @@ describe("Authorization", () => {
         }
       }`;
 
-      const result = await graphql(localSchema, query);
+      const result: ExecutionResult<any> = await graphql({
+        schema,
+        source: query,
+        contextValue: {},
+      });
 
       expect(result.data).toBeNull();
     });
@@ -340,7 +355,11 @@ describe("Authorization", () => {
         }
       }`;
 
-      const result = await graphql(localSchema, query);
+      const result: ExecutionResult<any> = await graphql({
+        schema,
+        source: query,
+        contextValue: {},
+      });
 
       expect(result.data!.normalObjectQuery.nullableAuthedField).toBeNull();
     });
@@ -356,7 +375,11 @@ describe("Authorization", () => {
         }
       }`;
 
-      const result = await graphql(localSchema, query);
+      const result: ExecutionResult<any> = await graphql({
+        schema,
+        source: query,
+        contextValue: {},
+      });
 
       expect(result.data).toBeNull();
       expect(result.errors).toHaveLength(1);
@@ -376,7 +399,11 @@ describe("Authorization", () => {
         }
       }`;
 
-      const result = await graphql(localSchema, query);
+      const result: ExecutionResult<any> = await graphql({
+        schema,
+        source: query,
+        contextValue: {},
+      });
 
       expect(result.data).toBeNull();
       expect(result.errors).toHaveLength(1);
@@ -396,7 +423,11 @@ describe("Authorization", () => {
         }
       }`;
 
-      const result = await graphql(localSchema, query, null, {});
+      const result: ExecutionResult<any> = await graphql({
+        schema: localSchema,
+        source: query,
+        contextValue: {},
+      });
 
       expect(result.data!.normalObjectQuery.authedField).toEqual("authedField");
     });
@@ -412,7 +443,11 @@ describe("Authorization", () => {
         }
       }`;
 
-      const result = await graphql(localSchema, query);
+      const result: ExecutionResult<any> = await graphql({
+        schema,
+        source: query,
+        contextValue: {},
+      });
 
       expect(result.data).toBeNull();
     });
@@ -428,7 +463,11 @@ describe("Authorization", () => {
         }
       }`;
 
-      const result = await graphql(localSchema, query);
+      const result: ExecutionResult<any> = await graphql({
+        schema,
+        source: query,
+        contextValue: {},
+      });
 
       expect(result.data).toBeNull();
     });
@@ -444,7 +483,11 @@ describe("Authorization", () => {
         }
       }`;
 
-      const result = await graphql(localSchema, query, null, {});
+      const result: ExecutionResult<any> = await graphql({
+        schema: localSchema,
+        source: query,
+        contextValue: {},
+      });
 
       expect(result.data!.normalObjectQuery.inlineAuthedResolvedField).toEqual(
         "inlineAuthedResolvedField",
@@ -464,7 +507,11 @@ describe("Authorization", () => {
         adminOrRegularQuery
       }`;
 
-      const result = await graphql(localSchema, query, null, {});
+      const result: ExecutionResult<any> = await graphql({
+        schema: localSchema,
+        source: query,
+        contextValue: {},
+      });
 
       expect(result.data!.adminOrRegularQuery).toEqual(false);
       expect(authCheckerRoles).toEqual(["ADMIN", "REGULAR"]);
@@ -483,12 +530,12 @@ describe("Authorization", () => {
         adminOrRegularQuery
       }`;
 
-      const result = await graphql(
-        localSchema,
-        query,
-        { field: "rootField" },
-        { field: "contextField" },
-      );
+      const result: ExecutionResult<any> = await graphql({
+        schema: localSchema,
+        source: query,
+        rootValue: { field: "rootField" },
+        contextValue: { field: "contextField" },
+      });
 
       expect(result.data!.adminOrRegularQuery).toEqual(false);
       expect(authCheckerResolverData.root.field).toEqual("rootField");
@@ -520,12 +567,12 @@ describe("Authorization", () => {
         }
       `;
 
-      const result = await graphql(
-        localSchema,
-        query,
-        { field: "rootField" },
-        { field: "contextField" },
-      );
+      const result: ExecutionResult<any> = await graphql({
+        schema: localSchema,
+        source: query,
+        rootValue: { field: "rootField" },
+        contextValue: { field: "contextField" },
+      });
 
       expect(result.data).toBeNull();
       expect(result.errors).toMatchInlineSnapshot(`

--- a/tests/functional/circular-refs.ts
+++ b/tests/functional/circular-refs.ts
@@ -1,5 +1,11 @@
 import "reflect-metadata";
-import { IntrospectionObjectType, TypeKind, GraphQLObjectType, graphql } from "graphql";
+import {
+  IntrospectionObjectType,
+  TypeKind,
+  GraphQLObjectType,
+  graphql,
+  ExecutionResult,
+} from "graphql";
 
 import { Query, ObjectType, Field, Resolver, buildSchema } from "../../src";
 import { getMetadataStorage } from "../../src/metadata/getMetadataStorage";
@@ -117,7 +123,7 @@ describe("Circular references", () => {
         }
       }
     `;
-    const { data } = await graphql(schema, query);
+    const { data }: ExecutionResult<any> = await graphql({ schema, source: query });
 
     expect(data!.objectQuery).toEqual({
       stringField: "stringField",

--- a/tests/functional/directives.ts
+++ b/tests/functional/directives.ts
@@ -6,6 +6,7 @@ import {
   GraphQLInputObjectType,
   GraphQLInterfaceType,
   GraphQLObjectType,
+  ExecutionResult,
 } from "graphql";
 import {
   Field,
@@ -289,7 +290,7 @@ describe("Directives", () => {
           queryWithUpper
         }`;
 
-        const { data } = await graphql(schema, query);
+        const { data }: ExecutionResult<any> = await graphql({ schema, source: query });
 
         expect(data).toHaveProperty("queryWithUpper", "QUERYWITHUPPER");
       });
@@ -299,7 +300,7 @@ describe("Directives", () => {
           queryWithUpperDefinition
         }`;
 
-        const { data } = await graphql(schema, query);
+        const { data }: ExecutionResult<any> = await graphql({ schema, source: query });
 
         expect(data).toHaveProperty("queryWithUpperDefinition", "QUERYWITHUPPER");
       });
@@ -309,7 +310,7 @@ describe("Directives", () => {
           queryWithAppend(append: ", world!")
         }`;
 
-        const { data } = await graphql(schema, query);
+        const { data }: ExecutionResult<any> = await graphql({ schema, source: query });
 
         expect(data).toHaveProperty("queryWithAppend", "hello, world!");
       });
@@ -319,7 +320,7 @@ describe("Directives", () => {
           queryWithAppendDefinition(append: ", world!")
         }`;
 
-        const { data } = await graphql(schema, query);
+        const { data }: ExecutionResult<any> = await graphql({ schema, source: query });
 
         expect(data).toHaveProperty("queryWithAppendDefinition", "hello, world!");
       });
@@ -329,7 +330,7 @@ describe("Directives", () => {
           queryWithUpperAndAppend(append: ", world!")
         }`;
 
-        const { data } = await graphql(schema, query);
+        const { data }: ExecutionResult<any> = await graphql({ schema, source: query });
 
         expect(data).toHaveProperty("queryWithUpperAndAppend", "HELLO, WORLD!");
       });
@@ -354,7 +355,7 @@ describe("Directives", () => {
           mutationWithUpper
         }`;
 
-        const { data } = await graphql(schema, mutation);
+        const { data }: ExecutionResult<any> = await graphql({ schema, source: mutation });
 
         expect(data).toHaveProperty("mutationWithUpper", "MUTATIONWITHUPPER");
       });
@@ -364,7 +365,7 @@ describe("Directives", () => {
           mutationWithUpperDefinition
         }`;
 
-        const { data } = await graphql(schema, mutation);
+        const { data }: ExecutionResult<any> = await graphql({ schema, source: mutation });
 
         expect(data).toHaveProperty("mutationWithUpperDefinition", "MUTATIONWITHUPPER");
       });
@@ -374,7 +375,7 @@ describe("Directives", () => {
           mutationWithAppend(append: ", world!")
         }`;
 
-        const { data } = await graphql(schema, mutation);
+        const { data }: ExecutionResult<any> = await graphql({ schema, source: mutation });
 
         expect(data).toHaveProperty("mutationWithAppend", "hello, world!");
       });
@@ -384,7 +385,7 @@ describe("Directives", () => {
           mutationWithAppendDefinition(append: ", world!")
         }`;
 
-        const { data } = await graphql(schema, mutation);
+        const { data }: ExecutionResult<any> = await graphql({ schema, source: mutation });
 
         expect(data).toHaveProperty("mutationWithAppendDefinition", "hello, world!");
       });
@@ -394,7 +395,7 @@ describe("Directives", () => {
           mutationWithUpperAndAppend(append: ", world!")
         }`;
 
-        const { data } = await graphql(schema, mutation);
+        const { data }: ExecutionResult<any> = await graphql({ schema, source: mutation });
 
         expect(data).toHaveProperty("mutationWithUpperAndAppend", "HELLO, WORLD!");
       });
@@ -457,7 +458,7 @@ describe("Directives", () => {
           }
       }`;
 
-        const { data } = await graphql(schema, query);
+        const { data }: ExecutionResult<any> = await graphql({ schema, source: query });
 
         expect(data).toHaveProperty("objectType");
         expect(data!.objectType).toEqual({
@@ -494,7 +495,7 @@ describe("Directives", () => {
           }
       }`;
 
-        const { data } = await graphql(schema, query);
+        const { data }: ExecutionResult<any> = await graphql({ schema, source: query });
 
         expect(data).toHaveProperty("subObjectType");
         expect(data!.subObjectType).toEqual({

--- a/tests/functional/emit-schema-sdl.ts
+++ b/tests/functional/emit-schema-sdl.ts
@@ -56,7 +56,7 @@ describe("Emitting schema definition file", () => {
 
   function checkSchemaSDL(
     SDL: string,
-    { commentDescriptions, sortedSchema }: PrintSchemaOptions = defaultPrintSchemaOptions,
+    { sortedSchema }: PrintSchemaOptions = defaultPrintSchemaOptions,
   ) {
     expect(SDL).toContain("THIS FILE WAS GENERATED");
     expect(SDL).toContain("MyObject");
@@ -65,11 +65,7 @@ describe("Emitting schema definition file", () => {
     } else {
       expect(SDL.indexOf("descriptionProperty")).toBeGreaterThan(SDL.indexOf("normalProperty"));
     }
-    if (commentDescriptions) {
-      expect(SDL).toContain(`# Description test`);
-    } else {
-      expect(SDL).toContain(`"""Description test"""`);
-    }
+    expect(SDL).toContain(`"""Description test"""`);
   }
 
   describe("emitSchemaDefinitionFile", () => {
@@ -83,7 +79,6 @@ describe("Emitting schema definition file", () => {
     it("should use provided options to write file with schema SDL", async () => {
       const targetPath = path.join(TEST_DIR, "schemas", "test1", "schema.gql");
       const options: PrintSchemaOptions = {
-        commentDescriptions: true,
         sortedSchema: false,
       };
       await emitSchemaDefinitionFile(targetPath, schema, options);
@@ -129,7 +124,6 @@ describe("Emitting schema definition file", () => {
     it("should use provided options to write file with schema SDL", async () => {
       const targetPath = path.join(TEST_DIR, "schemas", "test1", "schema.gql");
       const options: PrintSchemaOptions = {
-        commentDescriptions: true,
         sortedSchema: false,
       };
       emitSchemaDefinitionFileSync(targetPath, schema, options);
@@ -195,14 +189,12 @@ describe("Emitting schema definition file", () => {
       await buildSchema({
         resolvers: [MyResolverClass],
         emitSchemaFile: {
-          commentDescriptions: true,
           path: targetPath,
           sortedSchema: false,
         },
       });
       expect(fs.existsSync(targetPath)).toEqual(true);
       checkSchemaSDL(fs.readFileSync(targetPath).toString(), {
-        commentDescriptions: true,
         sortedSchema: false,
       });
     });
@@ -212,14 +204,11 @@ describe("Emitting schema definition file", () => {
       const targetPath = path.join(process.cwd(), "schema.gql");
       await buildSchema({
         resolvers: [MyResolverClass],
-        emitSchemaFile: {
-          commentDescriptions: true,
-        },
+        emitSchemaFile: {},
       });
       expect(fs.existsSync(targetPath)).toEqual(true);
       checkSchemaSDL(fs.readFileSync(targetPath).toString(), {
         ...defaultPrintSchemaOptions,
-        commentDescriptions: true,
       });
     });
   });
@@ -251,14 +240,12 @@ describe("Emitting schema definition file", () => {
       buildSchemaSync({
         resolvers: [MyResolverClass],
         emitSchemaFile: {
-          commentDescriptions: true,
           path: targetPath,
           sortedSchema: false,
         },
       });
       expect(fs.existsSync(targetPath)).toEqual(true);
       checkSchemaSDL(fs.readFileSync(targetPath).toString(), {
-        commentDescriptions: true,
         sortedSchema: false,
       });
     });
@@ -268,14 +255,11 @@ describe("Emitting schema definition file", () => {
       const targetPath = path.join(process.cwd(), "schema.gql");
       buildSchemaSync({
         resolvers: [MyResolverClass],
-        emitSchemaFile: {
-          commentDescriptions: true,
-        },
+        emitSchemaFile: {},
       });
       expect(fs.existsSync(targetPath)).toEqual(true);
       checkSchemaSDL(fs.readFileSync(targetPath).toString(), {
         ...defaultPrintSchemaOptions,
-        commentDescriptions: true,
       });
     });
   });

--- a/tests/functional/enums.ts
+++ b/tests/functional/enums.ts
@@ -7,6 +7,7 @@ import {
   graphql,
   GraphQLSchema,
   TypeKind,
+  ExecutionResult,
 } from "graphql";
 
 import { getSchemaInfo } from "../helpers/getSchemaInfo";
@@ -209,7 +210,7 @@ describe("Enums", () => {
       const query = `query {
         getNumberEnumValue(input: { numberEnumField: One })
       }`;
-      const result = await graphql(schema, query);
+      const result: ExecutionResult<any> = await graphql({ schema, source: query });
 
       expect(result.data!.getNumberEnumValue).toEqual("Two");
     });
@@ -218,7 +219,7 @@ describe("Enums", () => {
       const query = `query {
         getStringEnumValue(input: { stringEnumField: One })
       }`;
-      const result = await graphql(schema, query);
+      const result: ExecutionResult<any> = await graphql({ schema, source: query });
 
       expect(result.data!.getStringEnumValue).toEqual("Two");
     });
@@ -231,8 +232,8 @@ describe("Enums", () => {
         isNumberEnumEqualOne(enum: Two)
       }`;
 
-      const result1 = await graphql(schema, query1);
-      const result2 = await graphql(schema, query2);
+      const result1: ExecutionResult<any> = await graphql({ schema, source: query1 });
+      const result2: ExecutionResult<any> = await graphql({ schema, source: query2 });
 
       expect(result1.data!.isNumberEnumEqualOne).toEqual(true);
       expect(result2.data!.isNumberEnumEqualOne).toEqual(false);
@@ -246,8 +247,8 @@ describe("Enums", () => {
         isStringEnumEqualOne(enum: Two)
       }`;
 
-      const result1 = await graphql(schema, query1);
-      const result2 = await graphql(schema, query2);
+      const result1: ExecutionResult<any> = await graphql({ schema, source: query1 });
+      const result2: ExecutionResult<any> = await graphql({ schema, source: query2 });
 
       expect(result1.data!.isStringEnumEqualOne).toEqual(true);
       expect(result2.data!.isStringEnumEqualOne).toEqual(false);

--- a/tests/functional/generic-types.ts
+++ b/tests/functional/generic-types.ts
@@ -10,6 +10,7 @@ import {
   GraphQLSchema,
   IntrospectionSchema,
   IntrospectionInputObjectType,
+  ExecutionResult,
 } from "graphql";
 
 import { getSchemaInfo } from "../helpers/getSchemaInfo";
@@ -245,7 +246,7 @@ describe("Generic types", () => {
         }
       `;
 
-      const result = await graphql(schema, query);
+      const result: ExecutionResult<any> = await graphql({ schema, source: query });
 
       expect(result.data!.dogs).toEqual(dogsResponseMock);
     });
@@ -386,7 +387,7 @@ describe("Generic types", () => {
         }
       `;
 
-      const result = await graphql(schema, query);
+      const result: ExecutionResult<any> = await graphql({ schema, source: query });
 
       expect(result.data!.recipeEdge).toEqual(recipeEdgeResponse);
       expect(result.data!.friendshipEdge).toEqual({
@@ -472,7 +473,7 @@ describe("Generic types", () => {
         }
       `;
 
-      const result = await graphql(schema, document);
+      const result: ExecutionResult<any> = await graphql({ schema, source: document });
 
       expect(result.data!).toEqual({
         child: {

--- a/tests/functional/interface-resolvers-args.ts
+++ b/tests/functional/interface-resolvers-args.ts
@@ -6,6 +6,7 @@ import {
   graphql,
   IntrospectionNonNullTypeRef,
   IntrospectionNamedTypeRef,
+  ExecutionResult,
 } from "graphql";
 
 import { getSchemaInfo } from "../helpers/getSchemaInfo";
@@ -309,7 +310,7 @@ describe("Interfaces with resolvers and arguments", () => {
         }
       `;
 
-      const { data, errors } = await graphql(schema, query);
+      const { data, errors }: ExecutionResult<any> = await graphql({ schema, source: query });
 
       expect(errors).toBeUndefined();
       const result = data!.queryForSampleInterfaceWithArgs.sampleFieldWithArgs;
@@ -326,7 +327,7 @@ describe("Interfaces with resolvers and arguments", () => {
         }
       `;
 
-      const { data, errors } = await graphql(schema, query);
+      const { data, errors }: ExecutionResult<any> = await graphql({ schema, source: query });
 
       expect(errors).toBeUndefined();
       const result = data!.queryForSampleInterfaceWithArgsAndInlineResolver.sampleFieldWithArgs;
@@ -343,7 +344,7 @@ describe("Interfaces with resolvers and arguments", () => {
         }
       `;
 
-      const { data, errors } = await graphql(schema, query);
+      const { data, errors }: ExecutionResult<any> = await graphql({ schema, source: query });
 
       expect(errors).toBeUndefined();
       const result = data!.queryForSampleInterfaceWithArgsAndFieldResolver.sampleFieldWithArgs;
@@ -360,7 +361,7 @@ describe("Interfaces with resolvers and arguments", () => {
         }
       `;
 
-      const { data, errors } = await graphql(schema, query);
+      const { data, errors }: ExecutionResult<any> = await graphql({ schema, source: query });
 
       expect(errors).toBeUndefined();
       const result = data!.queryForSampleImplementingObjectWithArgsAndOwnResolver
@@ -378,7 +379,7 @@ describe("Interfaces with resolvers and arguments", () => {
         }
       `;
 
-      const { data, errors } = await graphql(schema, query);
+      const { data, errors }: ExecutionResult<any> = await graphql({ schema, source: query });
 
       expect(errors).toBeUndefined();
       const result = data!.queryForSampleImplementingObjectWithArgsAndInheritedResolver
@@ -396,7 +397,7 @@ describe("Interfaces with resolvers and arguments", () => {
         }
       `;
 
-      const { data, errors } = await graphql(schema, query);
+      const { data, errors }: ExecutionResult<any> = await graphql({ schema, source: query });
 
       expect(errors).toBeUndefined();
       const result = data!.queryForSampleImplementingObjectWithArgsAndInheritedFieldResolver
@@ -414,7 +415,7 @@ describe("Interfaces with resolvers and arguments", () => {
         }
       `;
 
-      const { data, errors } = await graphql(schema, query);
+      const { data, errors }: ExecutionResult<any> = await graphql({ schema, source: query });
 
       expect(errors).toBeUndefined();
       const result = data!.queryForSampleInterfaceImplementingInterfaceWithArgsAndInlineResolver

--- a/tests/functional/interfaces-and-inheritance.ts
+++ b/tests/functional/interfaces-and-inheritance.ts
@@ -9,6 +9,7 @@ import {
   GraphQLSchema,
   graphql,
   TypeKind,
+  ExecutionResult,
 } from "graphql";
 
 import { getSchemaInfo } from "../helpers/getSchemaInfo";
@@ -805,7 +806,7 @@ describe("Interfaces and inheritance", () => {
         }
       }`;
 
-      const result = await graphql(schema, query);
+      const result: ExecutionResult<any> = await graphql({ schema, source: query });
       const data = result.data!.getFirstInterfaceImplementationObject;
       expect(data.baseInterfaceField).toEqual("baseInterfaceField");
     });
@@ -823,7 +824,7 @@ describe("Interfaces and inheritance", () => {
         }
       }`;
 
-      const result = await graphql(schema, query);
+      const result: ExecutionResult<any> = await graphql({ schema, source: query });
       const data = result.data!.getFirstInterfaceImplementationObject;
       expect(data.baseInterfaceField).toEqual("baseInterfaceField");
       expect(data.firstField).toEqual("firstField");
@@ -843,7 +844,7 @@ describe("Interfaces and inheritance", () => {
         }
       }`;
 
-      const result = await graphql(schema, query);
+      const result: ExecutionResult<any> = await graphql({ schema, source: query });
       const data = result.data!.getSecondInterfaceWithStringResolveTypeObject;
       expect(data.baseInterfaceField).toEqual("baseInterfaceField");
       expect(data.firstField).toBeUndefined();
@@ -863,7 +864,7 @@ describe("Interfaces and inheritance", () => {
         }
       }`;
 
-      const result = await graphql(schema, query);
+      const result: ExecutionResult<any> = await graphql({ schema, source: query });
       const data = result.data!.getSecondInterfaceWithClassResolveTypeObject;
       expect(data.baseInterfaceField).toEqual("baseInterfaceField");
       expect(data.firstField).toBeUndefined();
@@ -884,7 +885,7 @@ describe("Interfaces and inheritance", () => {
         }
       }`;
 
-      const result = await graphql(schema, query);
+      const result: ExecutionResult<any> = await graphql({ schema, source: query });
 
       expect(result.errors?.[0]?.message).toMatchInlineSnapshot(
         `"Abstract type \\"InterfaceWithClassResolveType\\" must resolve to an Object type at runtime for field \\"Query.notMatchingValueForInterfaceWithClassResolveTypeObject\\". Either the \\"InterfaceWithClassResolveType\\" type should provide a \\"resolveType\\" function or each possible type should provide an \\"isTypeOf\\" function."`,
@@ -898,7 +899,7 @@ describe("Interfaces and inheritance", () => {
         }
       }`;
 
-      const result = await graphql(schema, query);
+      const result: ExecutionResult<any> = await graphql({ schema, source: query });
 
       expect(result.data).toBeNull();
       expect(result.errors).toHaveLength(1);
@@ -920,7 +921,7 @@ describe("Interfaces and inheritance", () => {
         }
       }`;
 
-      const result = await graphql(schema, query);
+      const result: ExecutionResult<any> = await graphql({ schema, source: query });
       const data = result.data!.getFirstInterfaceImplementationObject;
       expect(data.baseInterfaceField).toEqual("baseInterfaceField");
       expect(data.firstField).toEqual("firstField");
@@ -933,7 +934,10 @@ describe("Interfaces and inheritance", () => {
         }
       }`;
 
-      const { data, errors } = await graphql(schema, query);
+      const { data, errors }: ExecutionResult<any> = await graphql({
+        schema,
+        source: query,
+      });
 
       expect(errors).toBeUndefined();
       expect(data!.renamedFieldInterfaceQuery.renamedInterfaceField).toEqual(
@@ -949,7 +953,7 @@ describe("Interfaces and inheritance", () => {
         )
       }`;
 
-      await graphql(schema, query);
+      await graphql({ schema, source: query });
 
       expect(queryArgs.baseArgField).toEqual("baseArgField");
       expect(queryArgs.childArgField).toEqual("childArgField");
@@ -964,7 +968,7 @@ describe("Interfaces and inheritance", () => {
         })
       }`;
 
-      await graphql(schema, query);
+      await graphql({ schema, source: query });
 
       expect(mutationInput.baseInputField).toEqual("baseInputField");
       expect(mutationInput.childInputField).toEqual("childInputField");
@@ -979,7 +983,7 @@ describe("Interfaces and inheritance", () => {
         )
       }`;
 
-      const { data } = await graphql(schema, query);
+      const { data }: ExecutionResult<any> = await graphql({ schema, source: query });
 
       expect(data!.baseClassQuery).toEqual("sampleStaticMethod");
       expect(inputFieldValue).toEqual("sampleInputValue");
@@ -996,7 +1000,7 @@ describe("Interfaces and inheritance", () => {
         })
       }`;
 
-      const { errors } = await graphql(schema, query);
+      const { errors }: ExecutionResult<any> = await graphql({ schema, source: query });
 
       expect(errors).toBeUndefined();
       expect(mutationInput).toEqual({
@@ -1015,7 +1019,10 @@ describe("Interfaces and inheritance", () => {
         }
       }`;
 
-      const { data, errors } = await graphql(schema, query);
+      const { data, errors }: ExecutionResult<any> = await graphql({
+        schema,
+        source: query,
+      });
 
       expect(errors).toBeUndefined();
       expect(data!.secondImplementationPlainQuery.baseInterfaceField).toEqual("baseInterfaceField");
@@ -1079,8 +1086,14 @@ describe("Interfaces and inheritance", () => {
         orphanedTypes: [One, Two],
         validate: false,
       });
-      const firstResult = await graphql(firstSchema, query);
-      const secondResult = await graphql(secondSchema, query);
+      const firstResult: ExecutionResult<any> = await graphql({
+        schema: firstSchema,
+        source: query,
+      });
+      const secondResult: ExecutionResult<any> = await graphql({
+        schema: secondSchema,
+        source: query,
+      });
 
       expect(firstResult.errors).toBeUndefined();
       expect(firstResult.data!.base).toEqual({
@@ -1157,8 +1170,14 @@ describe("Interfaces and inheritance", () => {
         orphanedTypes: [One, Two],
         validate: false,
       });
-      const firstResult = await graphql(firstSchema, query);
-      const secondResult = await graphql(secondSchema, query);
+      const firstResult: ExecutionResult<any> = await graphql({
+        schema: firstSchema,
+        source: query,
+      });
+      const secondResult: ExecutionResult<any> = await graphql({
+        schema: secondSchema,
+        source: query,
+      });
 
       expect(firstResult.errors).toBeUndefined();
       expect(firstResult.data!.base).toEqual({
@@ -1235,8 +1254,15 @@ describe("Interfaces and inheritance", () => {
         orphanedTypes: [One, Two],
         validate: false,
       });
-      const firstResult = await graphql(firstSchema, query);
-      const secondResult = await graphql(secondSchema, query);
+
+      const firstResult: ExecutionResult<any> = await graphql({
+        schema: firstSchema,
+        source: query,
+      });
+      const secondResult: ExecutionResult<any> = await graphql({
+        schema: secondSchema,
+        source: query,
+      });
 
       expect(firstResult.errors).toBeUndefined();
       expect(firstResult.data!.base).toEqual({

--- a/tests/functional/ioc-container.ts
+++ b/tests/functional/ioc-container.ts
@@ -1,5 +1,5 @@
 import "reflect-metadata";
-import { graphql } from "graphql";
+import { ExecutionResult, graphql } from "graphql";
 import { Container, Service } from "typedi";
 
 import { getMetadataStorage } from "../../src/metadata/getMetadataStorage";
@@ -54,7 +54,7 @@ describe("IOC container", () => {
         }
       }
     `;
-    await graphql(schema, query);
+    await graphql({ schema, source: query });
 
     expect(serviceValue).toEqual(initValue);
   });
@@ -86,10 +86,10 @@ describe("IOC container", () => {
         }
       }
     `;
-    await graphql(schema, query);
+    await graphql({ schema, source: query });
     const firstCallValue = resolverValue;
     resolverValue = undefined;
-    await graphql(schema, query);
+    await graphql({ schema, source: query });
     const secondCallValue = resolverValue;
 
     expect(firstCallValue).toBeDefined();
@@ -126,7 +126,8 @@ describe("IOC container", () => {
     `;
 
     const requestId = Math.random();
-    await graphql(schema, query, null, { requestId });
+    await graphql({ schema, source: query, contextValue: { requestId } });
+
     expect(contextRequestId).toEqual(requestId);
   });
 
@@ -166,7 +167,7 @@ describe("IOC container", () => {
       container: mockedContainer,
     };
 
-    await graphql(schema, query, null, queryContext);
+    await graphql({ schema, source: query, contextValue: queryContext });
 
     expect(called).toEqual(true);
   });
@@ -201,8 +202,7 @@ describe("IOC container", () => {
         sampleQuery(sampleArg: "sampleArgValue")
       }
     `;
-
-    const result = await graphql(schema, query);
+    const result: ExecutionResult<any> = await graphql({ schema, source: query });
 
     expect(result.errors).toBeUndefined();
     expect(result.data!.sampleQuery).toEqual("sampleArgValue");

--- a/tests/functional/middlewares.ts
+++ b/tests/functional/middlewares.ts
@@ -1,5 +1,5 @@
 import "reflect-metadata";
-import { GraphQLSchema, graphql } from "graphql";
+import { GraphQLSchema, graphql, ExecutionResult } from "graphql";
 
 import { getMetadataStorage } from "../../src/metadata/getMetadataStorage";
 import {
@@ -235,7 +235,7 @@ describe("Middlewares", () => {
       normalQuery
     }`;
 
-    const { data } = await graphql(schema, query);
+    const { data }: ExecutionResult<any> = await graphql({ schema, source: query });
 
     expect(data!.normalQuery).toEqual(true);
   });
@@ -245,7 +245,7 @@ describe("Middlewares", () => {
       middlewareOrderQuery
     }`;
 
-    const { data } = await graphql(schema, query);
+    const { data }: ExecutionResult<any> = await graphql({ schema, source: query });
 
     expect(data!.middlewareOrderQuery).toEqual("middlewareOrderQueryResult");
 
@@ -264,7 +264,7 @@ describe("Middlewares", () => {
       multipleMiddlewareDecoratorsQuery
     }`;
 
-    const { data } = await graphql(schema, query);
+    const { data }: ExecutionResult<any> = await graphql({ schema, source: query });
 
     expect(data!.multipleMiddlewareDecoratorsQuery).toEqual(
       "multipleMiddlewareDecoratorsQueryResult",
@@ -285,7 +285,7 @@ describe("Middlewares", () => {
       middlewareInterceptQuery
     }`;
 
-    const { data } = await graphql(schema, query);
+    const { data }: ExecutionResult<any> = await graphql({ schema, source: query });
 
     expect(data!.middlewareInterceptQuery).toEqual("interceptMiddleware");
     expect(middlewareLogs).toHaveLength(2);
@@ -298,7 +298,7 @@ describe("Middlewares", () => {
       middlewareReturnUndefinedQuery
     }`;
 
-    const { data } = await graphql(schema, query);
+    const { data }: ExecutionResult<any> = await graphql({ schema, source: query });
 
     expect(data!.middlewareReturnUndefinedQuery).toEqual("middlewareReturnUndefinedQueryResult");
     expect(middlewareLogs).toHaveLength(4);
@@ -313,7 +313,7 @@ describe("Middlewares", () => {
       middlewareErrorCatchQuery(throwError: true)
     }`;
 
-    const { data } = await graphql(schema, query);
+    const { data }: ExecutionResult<any> = await graphql({ schema, source: query });
 
     expect(data!.middlewareErrorCatchQuery).toEqual("errorCatchMiddleware");
     expect(middlewareLogs).toHaveLength(2);
@@ -326,7 +326,7 @@ describe("Middlewares", () => {
       middlewareErrorCatchQuery(throwError: false)
     }`;
 
-    const { data } = await graphql(schema, query);
+    const { data }: ExecutionResult<any> = await graphql({ schema, source: query });
 
     expect(data!.middlewareErrorCatchQuery).toEqual("middlewareErrorCatchQueryResult");
   });
@@ -336,7 +336,7 @@ describe("Middlewares", () => {
       middlewareThrowErrorAfterQuery
     }`;
 
-    const { errors } = await graphql(schema, query);
+    const { errors }: ExecutionResult<any> = await graphql({ schema, source: query });
 
     expect(errors).toHaveLength(1);
     expect(errors![0].message).toEqual("errorThrowAfterMiddleware");
@@ -350,7 +350,7 @@ describe("Middlewares", () => {
       middlewareThrowErrorQuery
     }`;
 
-    const { errors } = await graphql(schema, query);
+    const { errors }: ExecutionResult<any> = await graphql({ schema, source: query });
 
     expect(errors).toHaveLength(1);
     expect(errors![0].message).toEqual("errorThrowMiddleware");
@@ -365,7 +365,7 @@ describe("Middlewares", () => {
       }
     }`;
 
-    const { data } = await graphql(schema, query);
+    const { data }: ExecutionResult<any> = await graphql({ schema, source: query });
 
     expect(data!.sampleObjectQuery.resolverField).toEqual("resolverField");
     expect(middlewareLogs).toHaveLength(3);
@@ -379,7 +379,7 @@ describe("Middlewares", () => {
       classMiddlewareQuery
     }`;
 
-    const { data } = await graphql(schema, query);
+    const { data }: ExecutionResult<any> = await graphql({ schema, source: query });
 
     expect(data!.classMiddlewareQuery).toEqual("classMiddlewareQueryResult");
     expect(middlewareLogs).toHaveLength(3);
@@ -393,7 +393,7 @@ describe("Middlewares", () => {
       customMethodDecoratorQuery
     }`;
 
-    const { data } = await graphql(schema, query);
+    const { data }: ExecutionResult<any> = await graphql({ schema, source: query });
 
     expect(data!.customMethodDecoratorQuery).toEqual("customMethodDecoratorQuery");
     expect(middlewareLogs).toHaveLength(2);
@@ -408,7 +408,7 @@ describe("Middlewares", () => {
       }
     }`;
 
-    const { data } = await graphql(schema, query);
+    const { data }: ExecutionResult<any> = await graphql({ schema, source: query });
 
     expect(data!.sampleObjectQuery.middlewareField).toEqual("middlewareField");
     expect(middlewareLogs).toHaveLength(2);
@@ -421,7 +421,7 @@ describe("Middlewares", () => {
       doubleNextMiddlewareQuery
     }`;
 
-    const { errors } = await graphql(schema, query);
+    const { errors }: ExecutionResult<any> = await graphql({ schema, source: query });
 
     expect(errors).toHaveLength(1);
     expect(errors![0].message).toEqual("next() called multiple times");
@@ -448,7 +448,7 @@ describe("Middlewares", () => {
       middlewareOrderQuery
     }`;
 
-    const { data } = await graphql(localSchema, query);
+    const { data }: ExecutionResult<any> = await graphql({ schema: localSchema, source: query });
 
     expect(data!.middlewareOrderQuery).toEqual("middlewareOrderQueryResult");
     expect(middlewareLogs).toHaveLength(11);

--- a/tests/functional/resolvers.ts
+++ b/tests/functional/resolvers.ts
@@ -17,6 +17,7 @@ import {
   visitWithTypeInfo,
   IntrospectionInputObjectType,
   GraphQLError,
+  ExecutionResult,
 } from "graphql";
 import * as path from "path";
 import { fieldExtensionsEstimator, simpleEstimator } from "graphql-query-complexity";
@@ -1537,7 +1538,7 @@ describe("Resolvers", () => {
         }
       }`;
 
-      const result = await graphql(schema, query);
+      const result: ExecutionResult<any> = await graphql({ schema, source: query });
 
       const getterFieldResult = result.data!.sampleQuery.getterField;
       expect(getterFieldResult).toBeGreaterThanOrEqual(0);
@@ -1551,7 +1552,7 @@ describe("Resolvers", () => {
         }
       }`;
 
-      const result = await graphql(schema, query);
+      const result: ExecutionResult<any> = await graphql({ schema, source: query });
 
       const methodFieldResult = result.data!.sampleQuery.methodField;
       expect(methodFieldResult).toBeGreaterThanOrEqual(0);
@@ -1565,7 +1566,7 @@ describe("Resolvers", () => {
         }
       }`;
 
-      const result = await graphql(schema, query);
+      const result: ExecutionResult<any> = await graphql({ schema, source: query });
 
       const asyncMethodFieldResult = result.data!.sampleQuery.asyncMethodField;
       expect(asyncMethodFieldResult).toEqual("asyncMethodField");
@@ -1578,7 +1579,7 @@ describe("Resolvers", () => {
         }
       }`;
 
-      const result = await graphql(schema, query);
+      const result: ExecutionResult<any> = await graphql({ schema, source: query });
 
       const methodFieldWithArgResult = result.data!.sampleQuery.methodFieldWithArg;
       expect(methodFieldWithArgResult).toBeGreaterThanOrEqual(0);
@@ -1592,7 +1593,7 @@ describe("Resolvers", () => {
         }
       }`;
 
-      const result = await graphql(schema, query);
+      const result: ExecutionResult<any> = await graphql({ schema, source: query });
 
       const fieldResolverFieldResult = result.data!.sampleQuery.fieldResolverField;
       expect(fieldResolverFieldResult).toBeGreaterThanOrEqual(0);
@@ -1606,7 +1607,7 @@ describe("Resolvers", () => {
         }
       }`;
 
-      const result = await graphql(schema, query);
+      const result: ExecutionResult<any> = await graphql({ schema, source: query });
 
       const fieldResolverGetterResult = result.data!.sampleQuery.fieldResolverGetter;
       expect(fieldResolverGetterResult).toBeGreaterThanOrEqual(0);
@@ -1620,7 +1621,7 @@ describe("Resolvers", () => {
         }
       }`;
 
-      const result = await graphql(schema, query);
+      const result: ExecutionResult<any> = await graphql({ schema, source: query });
 
       const fieldResolverMethodResult = result.data!.sampleQuery.fieldResolverMethod;
       expect(fieldResolverMethodResult).toBeGreaterThanOrEqual(0);
@@ -1656,7 +1657,7 @@ describe("Resolvers", () => {
         }
       }`;
 
-      const result = await graphql(schema, query);
+      const result: ExecutionResult<any> = await graphql({ schema, source: query });
 
       const resultFieldData = result.data!.sampleQuery.fieldResolverMethodWithArgs;
       expect(resultFieldData).toEqual(value);
@@ -1669,8 +1670,8 @@ describe("Resolvers", () => {
         }
       }`;
 
-      const result1 = await graphql(schema, query);
-      const result2 = await graphql(schema, query);
+      const result1: ExecutionResult<any> = await graphql({ schema, source: query });
+      const result2: ExecutionResult<any> = await graphql({ schema, source: query });
 
       const getterFieldResult1 = result1.data!.sampleQuery.getterField;
       const getterFieldResult2 = result2.data!.sampleQuery.getterField;
@@ -1687,7 +1688,7 @@ describe("Resolvers", () => {
         }
       `;
 
-      const result = await graphql(schema, query);
+      const result: ExecutionResult<any> = await graphql({ schema, source: query });
       const getterFieldValue = result.data!.sampleQuery.getterField;
       const methodFieldValue = result.data!.sampleQuery.getterField;
 
@@ -1702,8 +1703,8 @@ describe("Resolvers", () => {
         }
       }`;
 
-      const result1 = await graphql(schema, query);
-      const result2 = await graphql(schema, query);
+      const result1: ExecutionResult<any> = await graphql({ schema, source: query });
+      const result2: ExecutionResult<any> = await graphql({ schema, source: query });
 
       const resolverFieldResult1 = result1.data!.sampleQuery.fieldResolverField;
       const resolverFieldResult2 = result2.data!.sampleQuery.fieldResolverField;
@@ -1715,7 +1716,7 @@ describe("Resolvers", () => {
         mutationWithArgs(factor: 10)
       }`;
 
-      const mutationResult = await graphql(schema, mutation);
+      const mutationResult: ExecutionResult<any> = await graphql({ schema, source: mutation });
       const result = mutationResult.data!.mutationWithArgs;
 
       expect(result).toBeGreaterThanOrEqual(0);
@@ -1727,7 +1728,7 @@ describe("Resolvers", () => {
         mutationWithOptionalArgs(stringField: "stringField")
       }`;
 
-      const { errors } = await graphql(schema, mutation);
+      const { errors }: ExecutionResult<any> = await graphql({ schema, source: mutation });
 
       expect(errors).toBeUndefined();
       expect(mutationInputValue).toBeInstanceOf(classes.SampleOptionalArgs);
@@ -1739,7 +1740,7 @@ describe("Resolvers", () => {
         mutationWithInput(input: { factor: 10 })
       }`;
 
-      const mutationResult = await graphql(schema, mutation);
+      const mutationResult: ExecutionResult<any> = await graphql({ schema, source: mutation });
       const result = mutationResult.data!.mutationWithInput;
 
       expect(result).toBeGreaterThanOrEqual(0);
@@ -1758,7 +1759,7 @@ describe("Resolvers", () => {
         })
       }`;
 
-      const mutationResult = await graphql(schema, mutation);
+      const mutationResult: ExecutionResult<any> = await graphql({ schema, source: mutation });
       const result = mutationResult.data!.mutationWithNestedInputs;
 
       expect(result).toBeGreaterThanOrEqual(0);
@@ -1783,7 +1784,7 @@ describe("Resolvers", () => {
         })
       }`;
 
-      const mutationResult = await graphql(schema, mutation);
+      const mutationResult: ExecutionResult<any> = await graphql({ schema, source: mutation });
       expect(mutationResult.errors).toBeUndefined();
 
       const mutationWithNestedInputsData = mutationResult.data!.mutationWithNestedInputs;
@@ -1804,7 +1805,7 @@ describe("Resolvers", () => {
         mutationWithNestedArgsInput(factor: 20, input: { factor: 30 })
       }`;
 
-      const mutationResult = await graphql(schema, mutation);
+      const mutationResult: ExecutionResult<any> = await graphql({ schema, source: mutation });
       const result = mutationResult.data!.mutationWithNestedArgsInput;
 
       expect(result).toEqual(20);
@@ -1818,7 +1819,7 @@ describe("Resolvers", () => {
         mutationWithInputs(inputs: [{ factor: 30 }])
       }`;
 
-      const mutationResult = await graphql(schema, mutation);
+      const mutationResult: ExecutionResult<any> = await graphql({ schema, source: mutation });
       const result = mutationResult.data!.mutationWithInputs;
 
       expect(result).toEqual(30);
@@ -1832,7 +1833,7 @@ describe("Resolvers", () => {
         mutationWithTripleArrayInputs(inputs: [[[{ factor: 30 }]]])
       }`;
 
-      const mutationResult = await graphql(schema, mutation);
+      const mutationResult: ExecutionResult<any> = await graphql({ schema, source: mutation });
       const result = mutationResult.data!.mutationWithTripleArrayInputs;
       const nestedInput = mutationInputValue[0][0][0];
 
@@ -1856,7 +1857,7 @@ describe("Resolvers", () => {
         })
       }`;
 
-      const mutationResult = await graphql(schema, mutation);
+      const mutationResult: ExecutionResult<any> = await graphql({ schema, source: mutation });
       expect(mutationResult.errors).toBeUndefined();
 
       const result = mutationResult.data!.mutationWithTripleNestedInputs;
@@ -1880,7 +1881,7 @@ describe("Resolvers", () => {
         mutationWithOptionalArg
       }`;
 
-      const { data, errors } = await graphql(schema, mutation);
+      const { data, errors }: ExecutionResult<any> = await graphql({ schema, source: mutation });
       expect(errors).toBeUndefined();
       expect(data!.mutationWithOptionalArg).toBeDefined();
       expect(mutationInputValue).toEqual("undefined");
@@ -1894,7 +1895,7 @@ describe("Resolvers", () => {
         }
       }`;
 
-      const queryResult = await graphql(schema, query);
+      const queryResult: ExecutionResult<any> = await graphql({ schema, source: query });
       const fieldResolverWithRootValue = queryResult.data!.sampleQuery.fieldResolverWithRoot;
       const getterFieldValue = queryResult.data!.sampleQuery.getterField;
 
@@ -1911,7 +1912,7 @@ describe("Resolvers", () => {
         }
       }`;
 
-      const queryResult = await graphql(schema, query);
+      const queryResult: ExecutionResult<any> = await graphql({ schema, source: query });
       const fieldResolverWithRootValue = queryResult.data!.notInstanceQuery.fieldResolverWithRoot;
       const getterFieldValue = queryResult.data!.notInstanceQuery.getterField;
 
@@ -1927,7 +1928,7 @@ describe("Resolvers", () => {
       const root = { isRoot: true };
       const context = { isContext: true };
 
-      await graphql(schema, query, root, context);
+      await graphql({ schema, source: query, rootValue: root, contextValue: context });
 
       expect(queryRoot).toEqual(root);
       expect(queryContext).toEqual(context);
@@ -1942,7 +1943,7 @@ describe("Resolvers", () => {
       const root = { rootField: 2 };
       const context = { contextField: "present" };
 
-      await graphql(schema, query, root, context);
+      await graphql({ schema, source: query, rootValue: root, contextValue: context });
 
       expect(queryRoot).toEqual(2);
       expect(queryContext).toEqual("present");
@@ -1957,7 +1958,7 @@ describe("Resolvers", () => {
       const root = { rootField: 2 };
       const context = { contextField: "present" };
 
-      await graphql(schema, query, root, context);
+      await graphql({ schema, source: query, rootValue: root, contextValue: context });
 
       expect(queryFirstCustom.root).toEqual(root);
       expect(queryFirstCustom.context).toEqual(context);
@@ -1972,7 +1973,7 @@ describe("Resolvers", () => {
         }
       `;
 
-      const { data } = await graphql(schema, query);
+      const { data } = await graphql({ schema, source: query });
 
       expect(descriptorEvaluated).toBe(true);
       expect(data!.queryWithCustomDescriptorDecorator).toBe(true);
@@ -2067,7 +2068,7 @@ describe("Resolvers", () => {
           }
         }
       `;
-      const { data } = await graphql(schema, query);
+      const { data }: ExecutionResult<any> = await graphql({ schema, source: query });
 
       expect(data!.sampleQuerySync.sampleFieldSync).toEqual("sampleFieldSync");
     });
@@ -2142,7 +2143,7 @@ describe("Resolvers", () => {
         validate: false,
       });
 
-      const result = await graphql(schema, query);
+      const result: ExecutionResult<any> = await graphql({ schema, source: query });
 
       expect(result.errors).toBeUndefined();
       expect(result.data!.sampleQuery).toEqual({
@@ -2464,7 +2465,7 @@ describe("Resolvers", () => {
         prefixQuery(arg: true)
       }`;
 
-      const { data } = await graphql(schema, query);
+      const { data } = await graphql({ schema, source: query });
 
       expect(data!.prefixQuery).toEqual(true);
       expect(thisVar.constructor).toEqual(childResolver);
@@ -2475,7 +2476,7 @@ describe("Resolvers", () => {
         prefixMutation(arg: true)
       }`;
 
-      const { data } = await graphql(schema, mutation);
+      const { data }: ExecutionResult<any> = await graphql({ schema, source: mutation });
 
       expect(data!.prefixMutation).toEqual(true);
       expect(thisVar.constructor).toEqual(childResolver);
@@ -2486,7 +2487,7 @@ describe("Resolvers", () => {
         childQuery
       }`;
 
-      const { data } = await graphql(schema, query);
+      const { data } = await graphql({ schema, source: query });
 
       expect(data!.childQuery).toEqual(true);
       expect(thisVar.constructor).toEqual(childResolver);
@@ -2497,7 +2498,7 @@ describe("Resolvers", () => {
         childMutation
       }`;
 
-      const { data } = await graphql(schema, mutation);
+      const { data }: ExecutionResult<any> = await graphql({ schema, source: mutation });
 
       expect(data!.childMutation).toEqual(true);
       expect(thisVar.constructor).toEqual(childResolver);
@@ -2510,7 +2511,7 @@ describe("Resolvers", () => {
         }
       }`;
 
-      const { data } = await graphql(schema, query);
+      const { data }: ExecutionResult<any> = await graphql({ schema, source: query });
 
       expect(data!.objectQuery.resolverField).toEqual("resolverField");
       expect(thisVar.constructor).toEqual(childResolver);
@@ -2521,7 +2522,7 @@ describe("Resolvers", () => {
         overriddenQuery(overriddenArg: true)
       }`;
 
-      const { data } = await graphql(schema, query);
+      const { data } = await graphql({ schema, source: query });
 
       expect(data!.overriddenQuery).toEqual("overriddenQuery");
       expect(thisVar.constructor).toEqual(overrideResolver);
@@ -2532,7 +2533,7 @@ describe("Resolvers", () => {
         overriddenMutation(overriddenArg: true)
       }`;
 
-      const { data } = await graphql(schema, mutation);
+      const { data }: ExecutionResult<any> = await graphql({ schema, source: mutation });
 
       expect(data!.overriddenMutation).toEqual("overriddenMutationHandler");
       expect(thisVar.constructor).toEqual(overrideResolver);
@@ -2543,7 +2544,7 @@ describe("Resolvers", () => {
         childQuery
       }`;
 
-      await graphql(schema, query);
+      await graphql({ schema, source: query });
 
       expect(thisVar.name).toEqual("baseName");
     });
@@ -2553,7 +2554,7 @@ describe("Resolvers", () => {
         prefixQuery(arg: true)
       }`;
 
-      await graphql(schema, query);
+      await graphql({ schema, source: query });
 
       expect(thisVar).toBeInstanceOf(childResolver);
     });

--- a/tests/functional/scalars.ts
+++ b/tests/functional/scalars.ts
@@ -7,6 +7,7 @@ import {
   IntrospectionNonNullTypeRef,
   GraphQLSchema,
   TypeKind,
+  ExecutionResult,
 } from "graphql";
 
 import {
@@ -224,7 +225,7 @@ describe("Scalars", () => {
       const query = `query {
         returnScalar
       }`;
-      const result = await graphql(schema, query);
+      const result: ExecutionResult<any> = await graphql({ schema, source: query });
       const returnScalar = result.data!.returnScalar;
 
       expect(returnScalar).toEqual("TypeGraphQL serialize");
@@ -234,7 +235,7 @@ describe("Scalars", () => {
       const query = `query {
         argScalar(scalar: "test")
       }`;
-      await graphql(schema, query);
+      await graphql({ schema, source: query });
 
       expect(argScalar!).toEqual("TypeGraphQL parseLiteral");
     });
@@ -243,7 +244,7 @@ describe("Scalars", () => {
       const query = `query {
         objectArgScalar(scalar: "test")
       }`;
-      await graphql(schema, query);
+      await graphql({ schema, source: query });
 
       expect(argScalar!).toEqual({ value: "TypeGraphQL parseLiteral" });
     });
@@ -327,7 +328,7 @@ describe("Scalars", () => {
           returnDate
         }`;
         const beforeQuery = Date.now();
-        const result = await graphql(localSchema, query);
+        const result: ExecutionResult<any> = await graphql({ schema: localSchema, source: query });
         const afterQuery = Date.now();
         const returnDate = Date.parse(result.data!.returnDate);
 
@@ -340,7 +341,7 @@ describe("Scalars", () => {
           nullableReturnDate
         }`;
 
-        const result = await graphql(localSchema, query);
+        const result: ExecutionResult<any> = await graphql({ schema: localSchema, source: query });
 
         expect(result.errors).toBeUndefined();
         expect(result.data!.nullableReturnDate).toBeNull();
@@ -351,7 +352,10 @@ describe("Scalars", () => {
           returnStringAsDate
         }`;
 
-        const { errors } = await graphql(localSchema, query);
+        const { errors }: ExecutionResult<any> = await graphql({
+          schema: localSchema,
+          source: query,
+        });
 
         expect(errors).toHaveLength(1);
         expect(errors![0].message).toContain(`Unable to serialize value`);
@@ -363,7 +367,7 @@ describe("Scalars", () => {
         const query = `query {
           argDate(date: "${now.toISOString()}")
         }`;
-        await graphql(localSchema, query);
+        await graphql({ schema: localSchema, source: query });
 
         expect(now.getTime()).toEqual(localArgDate!.getTime());
       });
@@ -373,7 +377,10 @@ describe("Scalars", () => {
           argDate(date: true)
         }`;
 
-        const { errors } = await graphql(localSchema, query);
+        const { errors }: ExecutionResult<any> = await graphql({
+          schema: localSchema,
+          source: query,
+        });
 
         expect(errors).toHaveLength(1);
         expect(errors![0].message).toMatchInlineSnapshot(
@@ -386,7 +393,7 @@ describe("Scalars", () => {
           nullableArgDate(date: null)
         }`;
 
-        await graphql(localSchema, query);
+        await graphql({ schema: localSchema, source: query });
 
         expect(localArgDate).toBeNull();
       });
@@ -396,7 +403,7 @@ describe("Scalars", () => {
         const query = `query {
           inputDate(input: { date: "${now.toISOString()}" })
         }`;
-        await graphql(localSchema, query);
+        await graphql({ schema: localSchema, source: query });
 
         expect(now.getTime()).toEqual(localArgDate!.getTime());
       });
@@ -406,7 +413,10 @@ describe("Scalars", () => {
           inputDate(input: { date: true })
         }`;
 
-        const { errors } = await graphql(localSchema, query);
+        const { errors }: ExecutionResult<any> = await graphql({
+          schema: localSchema,
+          source: query,
+        });
 
         expect(errors).toHaveLength(1);
         expect(errors![0].message).toMatchInlineSnapshot(
@@ -420,7 +430,7 @@ describe("Scalars", () => {
           inputDate(input: { date: "${now.toISOString()}", nullableDate: null })
         }`;
 
-        const result = await graphql(localSchema, query);
+        const result: ExecutionResult<any> = await graphql({ schema: localSchema, source: query });
 
         expect(result.errors).toBeUndefined();
       });
@@ -495,7 +505,7 @@ describe("Scalars", () => {
           returnDate
         }`;
         const beforeQuery = Date.now();
-        const result = await graphql(localSchema, query);
+        const result: ExecutionResult<any> = await graphql({ schema: localSchema, source: query });
         const afterQuery = Date.now();
         const returnDate = result.data!.returnDate;
 
@@ -508,7 +518,7 @@ describe("Scalars", () => {
           nullableReturnDate
         }`;
 
-        const result = await graphql(localSchema, query);
+        const result: ExecutionResult<any> = await graphql({ schema: localSchema, source: query });
 
         expect(result.errors).toBeUndefined();
         expect(result.data!.nullableReturnDate).toBeNull();
@@ -519,7 +529,10 @@ describe("Scalars", () => {
           returnStringAsDate
         }`;
 
-        const { errors } = await graphql(localSchema, query);
+        const { errors }: ExecutionResult<any> = await graphql({
+          schema: localSchema,
+          source: query,
+        });
 
         expect(errors).toHaveLength(1);
         expect(errors![0].message).toContain(`Unable to serialize value`);
@@ -531,7 +544,7 @@ describe("Scalars", () => {
         const query = `query {
           argDate(date: ${now.getTime()})
         }`;
-        await graphql(localSchema, query);
+        await graphql({ schema: localSchema, source: query });
 
         expect(now.getTime()).toEqual(localArgDate!.getTime());
       });
@@ -541,7 +554,10 @@ describe("Scalars", () => {
           argDate(date: true)
         }`;
 
-        const { errors } = await graphql(localSchema, query);
+        const { errors }: ExecutionResult<any> = await graphql({
+          schema: localSchema,
+          source: query,
+        });
 
         expect(errors).toHaveLength(1);
         expect(errors![0].message).toMatchInlineSnapshot(
@@ -554,7 +570,7 @@ describe("Scalars", () => {
           nullableArgDate(date: null)
         }`;
 
-        await graphql(localSchema, query);
+        await graphql({ schema: localSchema, source: query });
 
         expect(localArgDate).toBeNull();
       });
@@ -564,7 +580,7 @@ describe("Scalars", () => {
         const query = `query {
           inputDate(input: {date: ${now.getTime()}})
         }`;
-        await graphql(localSchema, query);
+        await graphql({ schema: localSchema, source: query });
 
         expect(now.getTime()).toEqual(localArgDate!.getTime());
       });
@@ -574,7 +590,10 @@ describe("Scalars", () => {
           inputDate(input: { date: true })
         }`;
 
-        const { errors } = await graphql(localSchema, query);
+        const { errors }: ExecutionResult<any> = await graphql({
+          schema: localSchema,
+          source: query,
+        });
 
         expect(errors).toHaveLength(1);
         expect(errors![0].message).toMatchInlineSnapshot(
@@ -588,7 +607,7 @@ describe("Scalars", () => {
           inputDate(input: { date: ${now.getTime()}, nullableDate: null })
         }`;
 
-        const result = await graphql(localSchema, query);
+        const result: ExecutionResult<any> = await graphql({ schema: localSchema, source: query });
 
         expect(result.errors).toBeUndefined();
       });

--- a/tests/functional/subscriptions.ts
+++ b/tests/functional/subscriptions.ts
@@ -233,22 +233,24 @@ describe("Subscriptions", () => {
 
     async function subscribeOnceAndMutate(options: {
       mutation: DocumentNode;
-      mutationVariables?: object;
+      mutationVariables?: Record<any, any>;
       subscription: DocumentNode;
-      subscriptionVariables?: object;
+      subscriptionVariables?: Record<any, any>;
       onSubscribedData: (data: any) => void;
     }) {
-      const results = (await subscribe(
+      const results: any = (await subscribe({
         schema,
-        options.subscription,
-        null,
-        null,
-        options.subscriptionVariables,
-      )) as AsyncIterableIterator<ExecutionResult>;
-      const onDataPromise = results.next().then(async ({ value }) => {
+        document: options.subscription,
+        variableValues: options.subscriptionVariables,
+      })) as AsyncIterableIterator<ExecutionResult>;
+      const onDataPromise = results.next().then(async ({ value }: any) => {
         options.onSubscribedData(value.data);
       });
-      await execute(schema, options.mutation, null, null, options.mutationVariables);
+      await execute({
+        schema,
+        document: options.mutation,
+        variableValues: options.mutationVariables,
+      });
       await onDataPromise;
     }
 
@@ -324,7 +326,7 @@ describe("Subscriptions", () => {
         }
       `;
 
-      const subscription = (await subscribe({
+      const subscription: any = (await subscribe({
         schema,
         document: subscriptionQuery,
       })) as AsyncIterableIterator<ExecutionResult>;
@@ -395,7 +397,7 @@ describe("Subscriptions", () => {
         }
       `;
 
-      const subscription = (await subscribe({
+      const subscription: any = (await subscribe({
         schema,
         document: subscriptionQuery,
       })) as AsyncIterableIterator<ExecutionResult>;
@@ -434,7 +436,7 @@ describe("Subscriptions", () => {
         }
       `;
 
-      const subscription = (await subscribe({
+      const subscription: any = (await subscribe({
         schema,
         document: subscriptionQuery,
       })) as AsyncIterableIterator<ExecutionResult>;
@@ -478,7 +480,7 @@ describe("Subscriptions", () => {
         }
       `;
 
-      const subscription = (await subscribe({
+      const subscription: any = (await subscribe({
         schema,
         document: subscriptionQuery,
       })) as AsyncIterableIterator<ExecutionResult>;
@@ -590,7 +592,7 @@ describe("Subscriptions", () => {
         pubSub: customPubSub as any,
       });
 
-      await graphql(localSchema, mutation);
+      await graphql({ schema: localSchema, source: mutation });
 
       expect(pubSub).toEqual(customPubSub);
       expect(pubSub.myField).toEqual(true);
@@ -625,7 +627,7 @@ describe("Subscriptions", () => {
         resolvers: [SampleResolver],
         pubSub: { eventEmitter: customEmitter },
       });
-      await graphql(localSchema, mutation);
+      await graphql({ schema: localSchema, source: mutation });
 
       expect(emittedValue).toBeDefined();
       expect(emittedValue.test).toEqual(true);
@@ -698,7 +700,7 @@ describe("Subscriptions", () => {
         }
       `;
 
-      const subscribeResult = await subscribe(schema, document);
+      const subscribeResult = await subscribe({ schema, document });
 
       expect(subscribeResult).toHaveProperty("errors");
       const { errors } = subscribeResult as ExecutionResult;

--- a/tests/functional/typedefs-resolvers.ts
+++ b/tests/functional/typedefs-resolvers.ts
@@ -248,7 +248,10 @@ describe("typeDefs and resolvers", () => {
         typeDefs,
         resolvers,
       });
-      const introspectionResult = await graphql(schema, getIntrospectionQuery());
+      const introspectionResult: ExecutionResult<any> = await graphql({
+        schema,
+        source: getIntrospectionQuery(),
+      });
       schemaIntrospection = (introspectionResult.data as IntrospectionQuery).__schema;
     });
 
@@ -395,8 +398,7 @@ describe("typeDefs and resolvers", () => {
             sampleDateQuery
           }
         `;
-
-        const { data } = await execute(schema, document);
+        const { data }: ExecutionResult<any> = await execute({ schema, document });
         const parsedDate = new Date(data!.sampleDateQuery);
 
         expect(typeof data!.sampleDateQuery).toBe("string");
@@ -410,7 +412,7 @@ describe("typeDefs and resolvers", () => {
           }
         `;
 
-        const { data } = await execute(schema, document);
+        const { data } = await execute({ schema, document });
 
         expect(data!.sampleServiceQuery).toEqual("SampleString");
       });
@@ -422,7 +424,7 @@ describe("typeDefs and resolvers", () => {
           }
         `;
 
-        const { data } = await execute(schema, document);
+        const { data } = await execute({ schema, document });
 
         expect(data!.sampleMiddlewareBooleanQuery).toEqual(true);
         expect(middlewareLogs).toHaveLength(1);
@@ -436,7 +438,7 @@ describe("typeDefs and resolvers", () => {
           }
         `;
 
-        const { data } = await execute(schema, document);
+        const { data } = await execute({ schema, document });
 
         expect(data!.sampleBooleanMutation).toBe(true);
       });
@@ -448,7 +450,7 @@ describe("typeDefs and resolvers", () => {
           }
         `;
 
-        const { data } = await execute(schema, document);
+        const { data } = await execute({ schema, document });
 
         expect(data!.sampleMutationWithInput).toBe(true);
         expect(inputValue.constructor.name).toBe("SampleInput");
@@ -463,7 +465,7 @@ describe("typeDefs and resolvers", () => {
           }
         `;
 
-        const { errors } = await execute(schema, document);
+        const { errors } = await execute({ schema, document });
 
         expect(errors).toHaveLength(1);
         expect(errors![0].message).toContain("Argument Validation Error");
@@ -476,7 +478,7 @@ describe("typeDefs and resolvers", () => {
           }
         `;
 
-        const { errors } = await execute(schema, document);
+        const { errors } = await execute({ schema, document });
 
         expect(errors).toHaveLength(1);
         expect(errors![0].message).toContain("Access denied");
@@ -494,7 +496,7 @@ describe("typeDefs and resolvers", () => {
           }
         `;
 
-        const { data } = await execute(schema, document);
+        const { data } = await execute({ schema, document });
 
         expect(data!.sampleInterfaceQuery).toEqual({
           sampleInterfaceStringField: "sampleInterfaceStringField",
@@ -514,7 +516,7 @@ describe("typeDefs and resolvers", () => {
           }
         `;
 
-        const { data } = await execute(schema, document);
+        const { data } = await execute({ schema, document });
 
         expect(data!.sampleUnionQuery).toEqual({
           sampleInterfaceStringField: "sampleInterfaceStringField",
@@ -534,7 +536,7 @@ describe("typeDefs and resolvers", () => {
           }
         `;
 
-        const { data } = await execute(schema, document);
+        const { data } = await execute({ schema, document });
 
         expect(data!.sampleResolveUnionQuery).toEqual({
           sampleInterfaceStringField: "sampleInterfaceStringField",
@@ -549,7 +551,7 @@ describe("typeDefs and resolvers", () => {
           }
         `;
 
-        const { data } = await execute(schema, document);
+        const { data } = await execute({ schema, document });
 
         expect(data!.sampleNumberEnumQuery).toBe("OptionOne");
         expect(enumValue).toBe(0);
@@ -562,7 +564,7 @@ describe("typeDefs and resolvers", () => {
           }
         `;
 
-        const { data } = await execute(schema, document);
+        const { data } = await execute({ schema, document });
 
         expect(data!.sampleStringEnumQuery).toBe("OptionTwo");
         expect(enumValue).toBe("OptionTwoString");
@@ -576,7 +578,7 @@ describe("typeDefs and resolvers", () => {
         `;
         const payload = 5.4321;
 
-        const iterator = (await subscribe(schema, document)) as AsyncIterator<ExecutionResult>;
+        const iterator = (await subscribe({ schema, document })) as AsyncIterator<ExecutionResult>;
         const firstValuePromise = iterator.next();
         pubSub.publish("SAMPLE", payload);
         const data = await firstValuePromise;
@@ -637,7 +639,10 @@ describe("typeDefs and resolvers", () => {
         typeDefs,
         resolvers,
       });
-      const introspectionResult = await graphql(schema, getIntrospectionQuery());
+      const introspectionResult: ExecutionResult<any> = await graphql({
+        schema,
+        source: getIntrospectionQuery(),
+      });
       schemaIntrospection = (introspectionResult.data as IntrospectionQuery).__schema;
     });
 
@@ -677,7 +682,7 @@ describe("typeDefs and resolvers", () => {
           }
         `;
 
-        const { data, errors } = await execute(schema, document);
+        const { data, errors } = await execute({ schema, document });
 
         expect(errors).toBeUndefined();
         expect(data!.sampleBooleanQuery).toBe(true);

--- a/tests/functional/unions.ts
+++ b/tests/functional/unions.ts
@@ -6,6 +6,7 @@ import {
   GraphQLSchema,
   IntrospectionUnionType,
   TypeKind,
+  ExecutionResult,
 } from "graphql";
 
 import { getSchemaInfo } from "../helpers/getSchemaInfo";
@@ -216,7 +217,7 @@ describe("Unions", () => {
         }
       }`;
 
-      const result = await graphql(schema, query);
+      const result: ExecutionResult<any> = await graphql({ schema, source: query });
       const data = result.data!.getObjectOneFromUnion;
       expect(data.__typename).toEqual("ObjectTwo");
       expect(data.fieldTwo).toEqual("fieldTwo");
@@ -236,7 +237,7 @@ describe("Unions", () => {
         }
       }`;
 
-      const result = await graphql(schema, query);
+      const result: ExecutionResult<any> = await graphql({ schema, source: query });
       const data = result.data!.getObjectOneFromStringResolveTypeUnion;
       expect(data.__typename).toEqual("ObjectTwo");
       expect(data.fieldTwo).toEqual("fieldTwo");
@@ -256,7 +257,7 @@ describe("Unions", () => {
         }
       }`;
 
-      const result = await graphql(schema, query);
+      const result: ExecutionResult<any> = await graphql({ schema, source: query });
       const data = result.data!.getObjectOneFromClassResolveTypeUnion;
       expect(data.__typename).toEqual("ObjectTwo");
       expect(data.fieldTwo).toEqual("fieldTwo");
@@ -278,7 +279,7 @@ describe("Unions", () => {
         }
       }`;
 
-      const result = await graphql(schema, query);
+      const result: ExecutionResult<any> = await graphql({ schema, source: query });
       const unionFieldData = result.data!.getObjectWithUnion.unionField;
 
       expect(unionFieldData.__typename).toEqual("ObjectTwo");
@@ -299,7 +300,7 @@ describe("Unions", () => {
         }
       }`;
 
-      const result = await graphql(schema, query);
+      const result: ExecutionResult<any> = await graphql({ schema, source: query });
 
       expect(result.data).toBeNull();
       expect(result.errors).toHaveLength(1);
@@ -382,8 +383,14 @@ describe("Unions", () => {
       const secondSchema = await buildSchema({
         resolvers: [OneTwoResolver],
       });
-      const firstResult = await graphql(firstSchema, query);
-      const secondResult = await graphql(secondSchema, query);
+      const firstResult: ExecutionResult<any> = await graphql({
+        schema: firstSchema,
+        source: query,
+      });
+      const secondResult: ExecutionResult<any> = await graphql({
+        schema: secondSchema,
+        source: query,
+      });
 
       expect(firstResult.errors).toBeUndefined();
       expect(firstResult.data!.oneTwo).toEqual({
@@ -452,8 +459,14 @@ describe("Unions", () => {
       const secondSchema = await buildSchema({
         resolvers: [OneTwoResolver],
       });
-      const firstResult = await graphql(firstSchema, query);
-      const secondResult = await graphql(secondSchema, query);
+      const firstResult: ExecutionResult<any> = await graphql({
+        schema: firstSchema,
+        source: query,
+      });
+      const secondResult: ExecutionResult<any> = await graphql({
+        schema: secondSchema,
+        source: query,
+      });
 
       expect(firstResult.errors).toBeUndefined();
       expect(firstResult.data!.oneTwo).toEqual({
@@ -522,8 +535,14 @@ describe("Unions", () => {
       const secondSchema = await buildSchema({
         resolvers: [OneTwoResolver],
       });
-      const firstResult = await graphql(firstSchema, query);
-      const secondResult = await graphql(secondSchema, query);
+      const firstResult: ExecutionResult<any> = await graphql({
+        schema: firstSchema,
+        source: query,
+      });
+      const secondResult: ExecutionResult<any> = await graphql({
+        schema: secondSchema,
+        source: query,
+      });
 
       expect(firstResult.errors).toBeUndefined();
       expect(firstResult.data!.oneTwo).toEqual({
@@ -583,7 +602,7 @@ describe("Unions", () => {
       const testSchema = await buildSchema({
         resolvers: [OneTwoResolver],
       });
-      const result = await graphql(testSchema, query);
+      const result = await graphql({ schema: testSchema, source: query });
 
       expect(result.errors?.[0]?.message).toMatchInlineSnapshot(
         `"Abstract type \\"OneTwo\\" must resolve to an Object type at runtime for field \\"Query.oneTwo\\". Either the \\"OneTwo\\" type should provide a \\"resolveType\\" function or each possible type should provide an \\"isTypeOf\\" function."`,

--- a/tests/functional/validation.ts
+++ b/tests/functional/validation.ts
@@ -1,6 +1,6 @@
 import "reflect-metadata";
 import { MaxLength, Max, Min, ValidateNested } from "class-validator";
-import { GraphQLSchema, graphql } from "graphql";
+import { GraphQLSchema, graphql, ExecutionResult } from "graphql";
 
 import { getMetadataStorage } from "../../src/metadata/getMetadataStorage";
 import {
@@ -125,7 +125,7 @@ describe("Validation", () => {
           field
         }
       }`;
-      await graphql(schema, mutation);
+      await graphql({ schema, source: mutation });
 
       expect(argInput).toEqual({ stringField: "12345", numberField: 5 });
     });
@@ -140,7 +140,7 @@ describe("Validation", () => {
           field
         }
       }`;
-      await graphql(schema, mutation);
+      await graphql({ schema, source: mutation });
 
       expect(argInput).toEqual({ stringField: "12345", numberField: 5, optionalField: 5 });
     });
@@ -155,7 +155,7 @@ describe("Validation", () => {
         }
       }`;
 
-      const result = await graphql(schema, mutation);
+      const result: ExecutionResult<any> = await graphql({ schema, source: mutation });
       expect(result.data).toBeNull();
       expect(result.errors).toHaveLength(1);
 
@@ -179,7 +179,7 @@ describe("Validation", () => {
         }
       }`;
 
-      const result = await graphql(schema, mutation);
+      const result: ExecutionResult<any> = await graphql({ schema, source: mutation });
       expect(result.data).toBeNull();
       expect(result.errors).toHaveLength(1);
 
@@ -203,7 +203,7 @@ describe("Validation", () => {
         }
       }`;
 
-      const result = await graphql(schema, mutation);
+      const result: ExecutionResult<any> = await graphql({ schema, source: mutation });
       expect(result.data).toBeNull();
       expect(result.errors).toHaveLength(1);
 
@@ -229,7 +229,7 @@ describe("Validation", () => {
         }
       }`;
 
-      const result = await graphql(schema, mutation);
+      const result: ExecutionResult<any> = await graphql({ schema, source: mutation });
       expect(result.data).toBeNull();
       expect(result.errors).toHaveLength(1);
 
@@ -252,7 +252,7 @@ describe("Validation", () => {
         }
       }`;
 
-      const result = await graphql(schema, mutation);
+      const result: ExecutionResult<any> = await graphql({ schema, source: mutation });
       expect(result.errors).toBeUndefined();
       expect(result.data).toEqual({ mutationWithOptionalInputsArray: { field: null } });
     });
@@ -274,7 +274,7 @@ describe("Validation", () => {
         }
       }`;
 
-      const result = await graphql(schema, mutation);
+      const result: ExecutionResult<any> = await graphql({ schema, source: mutation });
       expect(result.data).toBeNull();
       expect(result.errors).toHaveLength(1);
 
@@ -295,7 +295,7 @@ describe("Validation", () => {
         }
       }`;
 
-      const result = await graphql(schema, mutation);
+      const result: ExecutionResult<any> = await graphql({ schema, source: mutation });
       expect(result.data).toBeNull();
       expect(result.errors).toHaveLength(1);
 
@@ -314,7 +314,7 @@ describe("Validation", () => {
         field
       }
     }`;
-      await graphql(schema, query);
+      await graphql({ schema, source: query });
 
       expect(argsData).toEqual({ stringField: "12345", numberField: 5 });
     });
@@ -329,7 +329,7 @@ describe("Validation", () => {
           field
         }
       }`;
-      await graphql(schema, query);
+      await graphql({ schema, source: query });
 
       expect(argsData).toEqual({ stringField: "12345", numberField: 5, optionalField: 5 });
     });
@@ -344,7 +344,7 @@ describe("Validation", () => {
         }
       }`;
 
-      const result = await graphql(schema, query);
+      const result = await graphql({ schema, source: query });
       expect(result.data).toBeNull();
       expect(result.errors).toHaveLength(1);
 
@@ -365,7 +365,7 @@ describe("Validation", () => {
         }
       }`;
 
-      const result = await graphql(schema, query);
+      const result = await graphql({ schema, source: query });
       expect(result.data).toBeNull();
       expect(result.errors).toHaveLength(1);
 
@@ -416,7 +416,7 @@ describe("Validation", () => {
           field
         }
       }`;
-      await graphql(localSchema, query);
+      await graphql({ schema: localSchema, source: query });
       expect(localArgsData).toEqual({ field: "12345678" });
     });
 
@@ -454,7 +454,7 @@ describe("Validation", () => {
           field
         }
       }`;
-      await graphql(localSchema, query);
+      await graphql({ schema: localSchema, source: query });
       expect(localArgsData).toEqual({ field: "12345678" });
     });
 
@@ -492,7 +492,7 @@ describe("Validation", () => {
           field
         }
       }`;
-      const result = await graphql(localSchema, query);
+      const result: ExecutionResult<any> = await graphql({ schema: localSchema, source: query });
       expect(result.data).toBeNull();
       expect(result.errors).toHaveLength(1);
 
@@ -536,7 +536,7 @@ describe("Validation", () => {
           field
         }
       }`;
-      const result = await graphql(localSchema, query);
+      const result: ExecutionResult<any> = await graphql({ schema: localSchema, source: query });
       expect(result.data).toBeNull();
       expect(result.errors).toHaveLength(1);
 
@@ -580,7 +580,7 @@ describe("Validation", () => {
           field
         }
       }`;
-      await graphql(localSchema, query);
+      await graphql({ schema: localSchema, source: query });
       expect(localArgsData).toEqual({ field: "123456789" });
     });
 
@@ -618,7 +618,8 @@ describe("Validation", () => {
           field
         }
       }`;
-      const { errors } = await graphql(localSchema, query);
+      const result: ExecutionResult<any> = await graphql({ schema: localSchema, source: query });
+      const { errors } = await graphql({ schema: localSchema, source: query });
       const error = errors![0].originalError! as ArgumentValidationError;
 
       expect(localArgsData).toBeUndefined();
@@ -676,7 +677,7 @@ describe("Custom validation", () => {
       },
     });
 
-    await graphql(schema, document);
+    await graphql({ schema, source: document });
 
     expect(validateArgs).toEqual([{ sampleField: "sampleFieldValue" }]);
     expect(validateArgs[0]).toBeInstanceOf(sampleArgsCls);
@@ -691,7 +692,7 @@ describe("Custom validation", () => {
       },
     });
 
-    await graphql(schema, document);
+    await graphql({ schema, source: document });
 
     expect(sampleQueryArgs).toEqual([{ sampleField: "sampleFieldValue" }]);
   });
@@ -704,7 +705,7 @@ describe("Custom validation", () => {
       },
     });
 
-    const result = await graphql(schema, document);
+    const result = await graphql({ schema, source: document });
 
     expect(result.errors).toHaveLength(1);
     expect(result.errors![0].message).toEqual("Test validate error");

--- a/tests/helpers/customScalar.ts
+++ b/tests/helpers/customScalar.ts
@@ -16,5 +16,5 @@ export const ObjectScalar = new GraphQLScalarType({
   parseValue: () => ({
     value: "TypeGraphQL parseValue",
   }),
-  serialize: obj => obj.value,
+  serialize: (obj: any) => obj.value,
 });

--- a/tests/helpers/directives/AppendDirective.ts
+++ b/tests/helpers/directives/AppendDirective.ts
@@ -1,5 +1,11 @@
 import { SchemaDirectiveVisitor } from "graphql-tools";
-import { GraphQLField, GraphQLString, GraphQLDirective, DirectiveLocation } from "graphql";
+import {
+  GraphQLField,
+  GraphQLString,
+  GraphQLDirective,
+  DirectiveLocation,
+  GraphQLArgument,
+} from "graphql";
 
 export class AppendDirective extends SchemaDirectiveVisitor {
   static getDirectiveDeclaration(directiveName: string): GraphQLDirective {
@@ -12,7 +18,7 @@ export class AppendDirective extends SchemaDirectiveVisitor {
   visitFieldDefinition(field: GraphQLField<any, any>) {
     const resolve = field.resolve;
 
-    field.args.push({
+    (field.args as GraphQLArgument[]).push({
       name: "append",
       description: "Appends a string to the end of a field",
       type: GraphQLString,

--- a/tests/helpers/getSchemaInfo.ts
+++ b/tests/helpers/getSchemaInfo.ts
@@ -3,6 +3,7 @@ import {
   getIntrospectionQuery,
   IntrospectionObjectType,
   IntrospectionSchema,
+  ExecutionResult,
 } from "graphql";
 
 import { buildSchema, BuildSchemaOptions } from "../../src";
@@ -16,7 +17,8 @@ export async function getSchemaInfo(options: BuildSchemaOptions) {
   });
 
   // get builded schema info from retrospection
-  const result = await graphql(schema, getIntrospectionQuery());
+  const result: ExecutionResult<any> = await graphql({ schema, source: getIntrospectionQuery() });
+
   expect(result.errors).toBeUndefined();
 
   const schemaIntrospection = result.data!.__schema as IntrospectionSchema;


### PR DESCRIPTION
Add support for graphql@16.x.x

The only BreakingChange is removing support for long deprecated comments as descriptions 
https://github.com/graphql/graphql-js/pull/2900