### PR TITLE
fix(validation): Fix arguments validation after updating the `class-validator`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "apollo-cache-control": "^0.11.6",
         "apollo-server": "^2.21.0",
         "apollo-server-plugin-response-cache": "^0.6.0",
-        "class-validator": "^0.13.1",
+        "class-validator": "^0.14.0",
         "del": "^6.0.0",
         "graphql": "^15.5.0",
         "graphql-redis-subscriptions": "^2.3.1",
@@ -2044,9 +2044,9 @@
       "dev": true
     },
     "node_modules/@types/validator": {
-      "version": "13.1.3",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.1.3.tgz",
-      "integrity": "sha512-DaOWN1zf7j+8nHhqXhIgNmS+ltAC53NXqGxYuBhWqWgqolRhddKzfZU814lkHQSTG0IUfQxU7Cg0gb8fFWo2mA==",
+      "version": "13.7.10",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.10.tgz",
+      "integrity": "sha512-t1yxFAR2n0+VO6hd/FJ9F2uezAZVWHLmpmlJzm1eX03+H7+HsuTAp7L8QJs+2pQCfWkP1+EXsGK9Z9v7o/qPVQ==",
       "dev": true
     },
     "node_modules/@types/vinyl": {
@@ -3719,14 +3719,14 @@
       }
     },
     "node_modules/class-validator": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.13.1.tgz",
-      "integrity": "sha512-zWIeYFhUitvAHBwNhDdCRK09hWx+P0HUwFE8US8/CxFpMVzkUK8RJl7yOIE+BVu2lxyPNgeOaFv78tLE47jBIg==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.0.tgz",
+      "integrity": "sha512-ct3ltplN8I9fOwUd8GrP8UQixwff129BkEtuWDKL5W45cQuLd19xqmTLu5ge78YDm/fdje6FMt0hGOhl0lii3A==",
       "dev": true,
       "dependencies": {
-        "@types/validator": "^13.1.3",
-        "libphonenumber-js": "^1.9.7",
-        "validator": "^13.5.2"
+        "@types/validator": "^13.7.10",
+        "libphonenumber-js": "^1.10.14",
+        "validator": "^13.7.0"
       }
     },
     "node_modules/clean-stack": {
@@ -9133,9 +9133,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.7.tgz",
-      "integrity": "sha512-mDY7fCe6dXd1ZUvYr3Q0ZaoqZ1DVXDSjcqa3AMGyudEd0Tyf8PoHkQ+9NucIBy9C/wFITPwL3Ef9SA148q20Cw==",
+      "version": "1.10.15",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.15.tgz",
+      "integrity": "sha512-sLeVLmWX17VCKKulc+aDIRHS95TxoTsKMRJi5s5gJdwlqNzMWcBCtSHHruVyXjqfi67daXM2SnLf2juSrdx5Sg==",
       "dev": true
     },
     "node_modules/liftoff": {
@@ -14449,9 +14449,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.5.2.tgz",
-      "integrity": "sha512-mD45p0rvHVBlY2Zuy3F3ESIe1h5X58GPfAtslBjY7EtTqGquZTj+VX/J4RnHWN8FKq0C9WRVt1oWAcytWRuYLQ==",
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
       "dev": true,
       "engines": {
         "node": ">= 0.10"
@@ -16747,9 +16747,9 @@
       "dev": true
     },
     "@types/validator": {
-      "version": "13.1.3",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.1.3.tgz",
-      "integrity": "sha512-DaOWN1zf7j+8nHhqXhIgNmS+ltAC53NXqGxYuBhWqWgqolRhddKzfZU814lkHQSTG0IUfQxU7Cg0gb8fFWo2mA==",
+      "version": "13.7.10",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.10.tgz",
+      "integrity": "sha512-t1yxFAR2n0+VO6hd/FJ9F2uezAZVWHLmpmlJzm1eX03+H7+HsuTAp7L8QJs+2pQCfWkP1+EXsGK9Z9v7o/qPVQ==",
       "dev": true
     },
     "@types/vinyl": {
@@ -18073,14 +18073,14 @@
       }
     },
     "class-validator": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.13.1.tgz",
-      "integrity": "sha512-zWIeYFhUitvAHBwNhDdCRK09hWx+P0HUwFE8US8/CxFpMVzkUK8RJl7yOIE+BVu2lxyPNgeOaFv78tLE47jBIg==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.0.tgz",
+      "integrity": "sha512-ct3ltplN8I9fOwUd8GrP8UQixwff129BkEtuWDKL5W45cQuLd19xqmTLu5ge78YDm/fdje6FMt0hGOhl0lii3A==",
       "dev": true,
       "requires": {
-        "@types/validator": "^13.1.3",
-        "libphonenumber-js": "^1.9.7",
-        "validator": "^13.5.2"
+        "@types/validator": "^13.7.10",
+        "libphonenumber-js": "^1.10.14",
+        "validator": "^13.7.0"
       }
     },
     "clean-stack": {
@@ -22291,9 +22291,9 @@
       }
     },
     "libphonenumber-js": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.7.tgz",
-      "integrity": "sha512-mDY7fCe6dXd1ZUvYr3Q0ZaoqZ1DVXDSjcqa3AMGyudEd0Tyf8PoHkQ+9NucIBy9C/wFITPwL3Ef9SA148q20Cw==",
+      "version": "1.10.15",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.15.tgz",
+      "integrity": "sha512-sLeVLmWX17VCKKulc+aDIRHS95TxoTsKMRJi5s5gJdwlqNzMWcBCtSHHruVyXjqfi67daXM2SnLf2juSrdx5Sg==",
       "dev": true
     },
     "liftoff": {
@@ -26501,9 +26501,9 @@
       }
     },
     "validator": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.5.2.tgz",
-      "integrity": "sha512-mD45p0rvHVBlY2Zuy3F3ESIe1h5X58GPfAtslBjY7EtTqGquZTj+VX/J4RnHWN8FKq0C9WRVt1oWAcytWRuYLQ==",
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
       "dev": true
     },
     "value-or-function": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "apollo-cache-control": "^0.11.6",
     "apollo-server": "^2.21.0",
     "apollo-server-plugin-response-cache": "^0.6.0",
-    "class-validator": "^0.13.1",
+    "class-validator": "^0.14.0",
     "del": "^6.0.0",
     "graphql": "^15.5.0",
     "graphql-redis-subscriptions": "^2.3.1",

--- a/src/resolvers/validate-arg.ts
+++ b/src/resolvers/validate-arg.ts
@@ -32,6 +32,10 @@ export async function validateArg<T extends object>(
     validatorOptions.skipMissingProperties = true;
   }
 
+  // Returning the old behavior of “class-validator”.
+  // Since 0.14.0 the “forbidUnknownValues” is really set to true by default :-).
+  validatorOptions.forbidUnknownValues = false;
+
   const { validateOrReject } = await import("class-validator");
   try {
     if (Array.isArray(argValue)) {


### PR DESCRIPTION
In order to get rid of [CVE-2019-18413](https://devhub.checkmarx.com/cve-details/CVE-2019-18413/) present in old versions of `class-validator`. There was a bug in the old version of `class-validator`, which lead to run validation with `forbidUnknownValues` enabled. So, to return the old behavior, enabling it explicitly now.