### PR TITLE
Allow @Directive in @ArgsType

### DIFF
--- a/src/schema/schema-generator.ts
+++ b/src/schema/schema-generator.ts
@@ -582,23 +582,22 @@ export abstract class SchemaGenerator {
   }
 
   private static buildOtherTypes(orphanedTypes: Function[]): GraphQLNamedType[] {
-    const autoRegisteredObjectTypesInfo = this.objectTypesInfo.filter(
-      typeInfo =>
-        typeInfo.metadata.interfaceClasses?.some(interfaceClass => {
-          const implementedInterfaceInfo = this.interfaceTypesInfo.find(
-            it => it.target === interfaceClass,
-          );
-          if (!implementedInterfaceInfo) {
-            return false;
-          }
-          if (implementedInterfaceInfo.metadata.autoRegisteringDisabled) {
-            return false;
-          }
-          if (!this.usedInterfaceTypes.has(interfaceClass)) {
-            return false;
-          }
-          return true;
-        }),
+    const autoRegisteredObjectTypesInfo = this.objectTypesInfo.filter(typeInfo =>
+      typeInfo.metadata.interfaceClasses?.some(interfaceClass => {
+        const implementedInterfaceInfo = this.interfaceTypesInfo.find(
+          it => it.target === interfaceClass,
+        );
+        if (!implementedInterfaceInfo) {
+          return false;
+        }
+        if (implementedInterfaceInfo.metadata.autoRegisteringDisabled) {
+          return false;
+        }
+        if (!this.usedInterfaceTypes.has(interfaceClass)) {
+          return false;
+        }
+        return true;
+      }),
     );
     return [
       ...this.filterTypesInfoByOrphanedTypesAndExtractType(this.objectTypesInfo, orphanedTypes),
@@ -740,13 +739,16 @@ export abstract class SchemaGenerator {
         argumentType.name,
       );
       // eslint-disable-next-line no-param-reassign
+      const type = this.getGraphQLInputType(field.target, field.name, field.getType(), {
+        ...field.typeOptions,
+        defaultValue,
+      });
       args[field.schemaName] = {
         description: field.description,
-        type: this.getGraphQLInputType(field.target, field.name, field.getType(), {
-          ...field.typeOptions,
-          defaultValue,
-        }),
+        type,
         defaultValue,
+        astNode: getInputValueDefinitionNode(field.name, type, field.directives),
+        extensions: field.extensions,
         deprecationReason: field.deprecationReason,
       };
     });

--- a/tests/helpers/directives/TestDirective.ts
+++ b/tests/helpers/directives/TestDirective.ts
@@ -91,5 +91,12 @@ export function testDirectiveTransformer(schema: GraphQLSchema): GraphQLSchema {
       }
       return fieldConfig;
     },
+    [MapperKind.ARGUMENT]: argConfig => {
+      const testDirectiveConfig = getDirective(schema, argConfig, testDirective.name)?.[0];
+      if (testDirectiveConfig) {
+        mapConfig(argConfig);
+      }
+      return argConfig;
+    },
   });
 }


### PR DESCRIPTION
When applying the `@Directive` to an `@ArgsType`, the result schema didn't applied the directives, differently than what we have seen with `@ObjectType`, `@Arg` or `@InputType`.

This PR solves this issue by adding `astNode` and `extensions` from `this.inputTypesInfo`.

Use case of `@Directive` within `@ArgsType`:
```ts
@ArgsType()
export class SomeArgs {
  @Directive('@spectaql(options:[{key:"example",value:"foo-bar"}])')
  @Field({description: 'Any description'}
  arg1: string

  @Directive('@spectaql(options:[{key:"example",value:"123"}])')
  @Field({description: 'Any description'}
  arg2: number
}
```