### PR TITLE
Add helpful comment about unique id in subscriptions resolver

### DIFF
--- a/examples/simple-subscriptions/resolver.ts
+++ b/examples/simple-subscriptions/resolver.ts
@@ -14,6 +14,8 @@ import { Notification, NotificationPayload } from "./notification.type";
 
 @Resolver()
 export class SampleResolver {
+  // This simple approach won't work for applications with multiple instances because the id isn't unique between multiple processes.  
+  // If you're using Apollo Client, you can bypass the requirement for a unique id by setting the fetchPolicy option to 'no-cache' in the useSubscription hook.
   private id = 0;
 
   @Query(_returns => Date)


### PR DESCRIPTION
The id is needed as a unique identifier for the Apollo Client cache. However, if the mongodb database har multiple instances, the naive approach in the documentation will be an issue since the id is only stored in-memory in each mongodb instance. Thus, there will be duplicates. 

Adding a comment about what the id is for gives the developer a chance to make an informed decision.