### PR TITLE
fix:(ci): workflows that depends on another workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,8 +26,10 @@ jobs:
           fetch-depth: 0
 
       - name: Check Git tag format
+        env:
+          TYPE_GRAPHQL_REF_NAME: ${{ github.ref_name }}
         run: |
-          _tag="${{ github.ref_name }}"
+          _tag="$TYPE_GRAPHQL_REF_NAME"
           if ! printf "%s\n" "$_tag" | grep -q -P '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(alpha|beta|rc)\.(0|[1-9][0-9]*))?$'; then
             printf '[ERROR]: Git tag (%s) wrong format\n' "$_tag"
             exit 1
@@ -49,14 +51,18 @@ jobs:
 
       - name: Remove leading v* from GitHub version
         id: version_github
+        env:
+          TYPE_GRAPHQL_VERSION: ${{ steps.version_v_github.outputs.release }}
         run: |
-          _version="${{ steps.version_v_github.outputs.release }}"
+          _version="$TYPE_GRAPHQL_VERSION"
           printf 'value=%s\n' "${_version#?}" >> "$GITHUB_OUTPUT"
 
       - name: Read Git tag version
         id: version_gittag
+        env:
+          TYPE_GRAPHQL_REF_NAME: ${{ github.ref_name }}
         run: |
-          _version="${{ github.ref_name }}"
+          _version="$TYPE_GRAPHQL_REF_NAME"
           printf 'value=%s\n' "${_version#?}" >> "$GITHUB_OUTPUT"
 
       - name: Compare package.json with Git tag
@@ -76,16 +82,24 @@ jobs:
           lenient: false
 
       - name: Check package.json == Git tag
+        env:
+          TYPE_GRAPHQL_COMPARISON: ${{ steps.comparison_package_gittag.outputs.comparison-result }}
+          TYPE_GRAPHQL_VERSION_PACKAGE: ${{ steps.version_package.outputs.value }}
+          TYPE_GRAPHQL_VERSION_TAG: ${{ steps.version_gittag.outputs.value }}
         run: |
-          if [ ! "${{ steps.comparison_package_gittag.outputs.comparison-result }}" = "=" ]; then
-            printf '[ERROR]: package.json (%s) != Git tag (%s)\n' "${{ steps.version_package.outputs.value }}" "${{ steps.version_gittag.outputs.value }}"
+          if [ ! "$TYPE_GRAPHQL_COMPARISON" = "=" ]; then
+            printf '[ERROR]: package.json (%s) != Git tag (%s)\n' "$TYPE_GRAPHQL_VERSION_PACKAGE" "$TYPE_GRAPHQL_VERSION_TAG"
             exit 1
           fi
 
       - name: Check Git tag > GitHub
+        env:
+          TYPE_GRAPHQL_COMPARISON: ${{ steps.comparison_gittag_github.outputs.comparison-result }}
+          TYPE_GRAPHQL_VERSION_TAG: ${{ steps.version_gittag.outputs.value }}
+          TYPE_GRAPHQL_VERSION_GITHUB: ${{ steps.version_github.outputs.value }}
         run: |
-          if [ ! "${{ steps.comparison_gittag_github.outputs.comparison-result }}" = ">" ]; then
-            printf '[ERROR]: Git tag (%s) !> GitHub (%s)\n' "${{ steps.version_gittag.outputs.value }}" "${{ steps.version_github.outputs.value }}"
+          if [ ! "$TYPE_GRAPHQL_COMPARISON" = ">" ]; then
+            printf '[ERROR]: Git tag (%s) !> GitHub (%s)\n' "$TYPE_GRAPHQL_VERSION_TAG" "$TYPE_GRAPHQL_VERSION_GITHUB"
             exit 1
           fi
 

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: "0 0 1 1 *"
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   license:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,26 +10,42 @@ on:
       - master
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:
   release:
     name: Release package on NPM
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success' && startsWith(github.ref_name, 'v')
+    if: github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'refs/tags/v')
     permissions:
       contents: write
       id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Read package.json version
         uses: sergeysova/jq-action@v2
         id: version
         with:
           cmd: jq --raw-output .version package.json
+
+      - name: Read Git tag version
+        id: tag
+        run: |
+          _ref="${{ github.event.workflow_run.head_branch }}"
+          printf 'value=%s\n' "${_ref#refs/tags/}" >> "$GITHUB_OUTPUT"
+
+      - name: Check package.json == Git tag
+        run: |
+          _version="v${{ steps.version.outputs.value }}"
+          if [ ! "$_version" = "${{ steps.tag.outputs.value }}" ]; then
+            printf '[ERROR]: package.json (%s) != Git tag (%s)\n' "$_version" "${{ steps.tag.outputs.value }}"
+            exit 1
+          fi
 
       - name: Determine if version is prerelease
         id: prerelease
@@ -61,7 +77,7 @@ jobs:
         run: |
           npm run prepublishOnly
         env:
-          TYPE_GRAPHQL_REF: ${{ github.ref_name }}
+          TYPE_GRAPHQL_REF: ${{ steps.tag.outputs.value }}
 
       - name: Build Changelog
         id: changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,23 +35,30 @@ jobs:
 
       - name: Read Git tag version
         id: tag
+        env:
+          TYPE_GRAPHQL_REF: ${{ github.event.workflow_run.head_branch }}
         run: |
-          _ref="${{ github.event.workflow_run.head_branch }}"
+          _ref="$TYPE_GRAPHQL_REF"
           printf 'value=%s\n' "${_ref#refs/tags/}" >> "$GITHUB_OUTPUT"
 
       - name: Check package.json == Git tag
+        env:
+          TYPE_GRAPHQL_VERSION_PACKAGE: ${{ steps.version.outputs.value }}
+          TYPE_GRAPHQL_VERSION_TAG: ${{ steps.tag.outputs.value }}
         run: |
-          _version="v${{ steps.version.outputs.value }}"
-          if [ ! "$_version" = "${{ steps.tag.outputs.value }}" ]; then
-            printf '[ERROR]: package.json (%s) != Git tag (%s)\n' "$_version" "${{ steps.tag.outputs.value }}"
+          _version="v$TYPE_GRAPHQL_VERSION_PACKAGE"
+          if [ ! "$_version" = "$TYPE_GRAPHQL_VERSION_TAG" ]; then
+            printf '[ERROR]: package.json (%s) != Git tag (%s)\n' "$_version" "$TYPE_GRAPHQL_VERSION_TAG"
             exit 1
           fi
 
       - name: Determine if version is prerelease
         id: prerelease
+        env:
+          TYPE_GRAPHQL_VERSION: ${{ steps.version.outputs.value }}
         run: |
           _prerelease=
-          if printf "%s\n" "${{ steps.version.outputs.value }}" | grep -q -P '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$'; then
+          if printf "%s\n" "$TYPE_GRAPHQL_VERSION" | grep -q -P '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$'; then
             _prerelease=false
           else
             _prerelease=true
@@ -95,14 +102,15 @@ jobs:
           prerelease: ${{ steps.prerelease.outputs.value == 'true' }}
 
       - name: Publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          TYPE_GRAPHQL_PRERELEASE: ${{ steps.prerelease.outputs.value }}
         run: |
           _tag=
-          if [ "${{ steps.prerelease.outputs.value }}" = "true" ]; then
+          if [ "$TYPE_GRAPHQL_PRERELEASE" = "true" ]; then
             _tag="next"
           else
             _tag="latest"
           fi
 
           npm publish --ignore-scripts --tag "$_tag"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -10,7 +10,7 @@ on:
       - master
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:
@@ -22,6 +22,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -46,4 +47,4 @@ jobs:
           user_name: "github-actions[bot]"
           user_email: "github-actions[bot]@users.noreply.github.com"
           full_commit_message: |
-            Deploy website based on ${{ github.sha }}
+            Deploy website based on ${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
- Fixed workflows that depends on another workflow
- `actions/checkout` always clone the corresponding `ref` to avoid clashes with `master`
- Cancel parallel workflows (`concurrency`) if the corresponding workflow must be run uniquely (e.g. `release` and `license`)