### PR TITLE
build: remove support for node 16

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
     "yargs": "^17.7.2"
   },
   "engines": {
-    "node": ">= 16.16.0"
+    "node": ">= 18.12.0"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
This PR should be merged only after PR #1610 is merged
Node.js 16 reached EOL (see https://nodejs.org/en/blog/announcements/nodejs16-eol) on September 11th, 2023