### PR TITLE
feat(subscriptions): allow passing subscription functions using class methods

### DIFF
--- a/src/decorators/Subscription.ts
+++ b/src/decorators/Subscription.ts
@@ -24,13 +24,14 @@ interface SubscribeOptions {
 
 export type SubscriptionOptions = AdvancedOptions & MergeExclusive<PubSubOptions, SubscribeOptions>;
 
+export function Subscription(): MethodDecorator;
 export function Subscription(options: SubscriptionOptions): MethodDecorator;
 export function Subscription(
   returnTypeFunc: ReturnTypeFunc,
-  options: SubscriptionOptions,
+  options?: SubscriptionOptions,
 ): MethodDecorator;
 export function Subscription(
-  returnTypeFuncOrOptions: ReturnTypeFunc | SubscriptionOptions,
+  returnTypeFuncOrOptions?: ReturnTypeFunc | SubscriptionOptions,
   maybeOptions?: SubscriptionOptions,
 ): MethodDecorator {
   const params = getTypeDecoratorParams(returnTypeFuncOrOptions, maybeOptions);


### PR DESCRIPTION
This PR allow passing subscription functions as class methods (_i.e._ the function decorated with `@Subscription`).

It solves the problems pointed in https://github.com/MichalLytek/type-graphql/issues/1638, namely:
1. Don't require `pubSub` parameter when not needed
2. Allow typed args using the known form`@Arg('from', type => Number) from: number`
3. Allow dependency injection

It's backwards compatible.

Tests and documentation are still missing. Please tell if you find this implementation good so I can continue on this.

Resolves: https://github.com/MichalLytek/type-graphql/issues/1638