### PR TITLE
fix(metadata): restore original metadata to enable repeated buildSchema executions

### DIFF
--- a/src/metadata/metadata-storage.ts
+++ b/src/metadata/metadata-storage.ts
@@ -34,6 +34,8 @@ import {
 } from "./utils";
 
 export class MetadataStorage {
+  original: MetadataStorage | null = null;
+
   queries: ResolverMetadata[] = [];
 
   mutations: ResolverMetadata[] = [];
@@ -160,6 +162,12 @@ export class MetadataStorage {
   }
 
   build(options: SchemaGeneratorOptions) {
+    if (!this.original) {
+      this.original = Object.assign(new MetadataStorage(), this);
+    } else {
+      Object.assign(this, this.original);
+    }
+
     this.classDirectives.reverse();
     this.fieldDirectives.reverse();
     this.argumentDirectives.reverse();
@@ -181,6 +189,7 @@ export class MetadataStorage {
   }
 
   clear() {
+    this.original = null;
     this.queries = [];
     this.mutations = [];
     this.subscriptions = [];


### PR DESCRIPTION
### Overview

This PR addresses the issue described in [#1321](https://github.com/MichalLytek/type-graphql/issues/1321), where the function [buildExtendedResolversMetadata](https://github.com/MichalLytek/type-graphql/blob/3a31dbe7818d4b0c5ce4733cc5e29da94855c8a8/src/metadata/metadata-storage.ts#L337) alters instance properties, causing multiple calls to buildSchema to exhibit unexpected behavior.

### Problem Statement

The primary problem is that buildExtendedResolversMetadata modifies the following instance properties of MetadataStorage:

- queries
- mutations
- subscriptions
- fieldResolvers

This mutation leads to issues when buildSchema is called multiple times, such as missing arguments in subsequent schema builds, as noted in the original issue.

### Solution

The proposed solution in this PR involves preserving the original state of MetadataStorage. On successive calls to buildSchema, the original instance of MetadataStorage is restored, ensuring that repeated schema builds do not encounter the unintended side effects of modified metadata.

### Implementation Details

- Save Original Metadata: Store the initial state of MetadataStorage upon the first invocation of buildSchema.
- Restore Metadata: Before subsequent calls to buildSchema, restore MetadataStorage to its original state.
