### PR TITLE
fix(schema): prevent issues with subsequent schema builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - make possible creating custom decorators on resolver class level - `createResolverClassMiddlewareDecorator`
 - support registering custom arg decorator via `createParameterDecorator` and its second argument `CustomParameterOptions` - `arg` (#1325)
 
+## Fixes
+
+- properly build multiple schemas with generic resolvers, args and field resolvers (#1321)
+
 ### Others
 
 - **Breaking Change**: update `graphql-scalars` peer dependency to `^1.23.0`

--- a/src/metadata/metadata-storage.ts
+++ b/src/metadata/metadata-storage.ts
@@ -80,8 +80,6 @@ export class MetadataStorage {
 
   params: ParamMetadata[] = [];
 
-  private hasAlreadyBeenBuilt = false;
-
   collectQueryHandlerMetadata(definition: ResolverMetadata) {
     this.queries.push(definition);
   }
@@ -176,12 +174,6 @@ export class MetadataStorage {
   }
 
   build(options: SchemaGeneratorOptions) {
-    if (this.hasAlreadyBeenBuilt) {
-      return;
-    }
-
-    this.hasAlreadyBeenBuilt = true;
-
     this.classDirectives.reverse();
     this.fieldDirectives.reverse();
     this.argumentDirectives.reverse();
@@ -222,11 +214,10 @@ export class MetadataStorage {
     this.argumentDirectives = [];
     this.classExtensions = [];
     this.fieldExtensions = [];
+
     this.resolverClasses = [];
     this.fields = [];
     this.params = [];
-
-    this.hasAlreadyBeenBuilt = false;
   }
 
   private buildClassMetadata(definitions: ClassMetadata[]) {

--- a/src/metadata/metadata-storage.ts
+++ b/src/metadata/metadata-storage.ts
@@ -80,6 +80,8 @@ export class MetadataStorage {
 
   params: ParamMetadata[] = [];
 
+  private hasAlreadyBeenBuilt = false;
+
   collectQueryHandlerMetadata(definition: ResolverMetadata) {
     this.queries.push(definition);
   }
@@ -174,6 +176,12 @@ export class MetadataStorage {
   }
 
   build(options: SchemaGeneratorOptions) {
+    if (this.hasAlreadyBeenBuilt) {
+      return;
+    }
+
+    this.hasAlreadyBeenBuilt = true;
+
     this.classDirectives.reverse();
     this.fieldDirectives.reverse();
     this.argumentDirectives.reverse();
@@ -214,10 +222,11 @@ export class MetadataStorage {
     this.argumentDirectives = [];
     this.classExtensions = [];
     this.fieldExtensions = [];
-
     this.resolverClasses = [];
     this.fields = [];
     this.params = [];
+
+    this.hasAlreadyBeenBuilt = false;
   }
 
   private buildClassMetadata(definitions: ClassMetadata[]) {

--- a/tests/functional/generic-types.ts
+++ b/tests/functional/generic-types.ts
@@ -408,7 +408,7 @@ describe("Generic types", () => {
     let schema: GraphQLSchema;
     let schemaIntrospection: IntrospectionSchema;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       function Base<TType extends object>(TTypeClass: ClassType<TType>) {
         @ObjectType()
         class BaseClass {

--- a/tests/functional/resolvers.ts
+++ b/tests/functional/resolvers.ts
@@ -2632,5 +2632,99 @@ describe("Resolvers", () => {
       expect(secondSchemaInfo.queryType.fields).toHaveLength(1);
       expect(secondSchemaInfo.queryType.fields[0].args).toHaveLength(1);
     });
+
+    it("should handle field resolvers correctly on multiple buildSchema runs", async () => {
+      @ObjectType()
+      class TestResponse {
+        @Field()
+        data!: string;
+      }
+
+      @ArgsType()
+      class TestArgs {
+        @Field(() => Int, { defaultValue: 0 })
+        testField!: number;
+      }
+
+      function makeResolverClass() {
+        @Resolver(() => TestResponse)
+        abstract class TestResolver {
+          @Query(() => TestResponse)
+          async exampleQuery(@Args() args: TestArgs): Promise<TestResponse> {
+            return {
+              data: `resolver ${args.testField}`,
+            };
+          }
+        }
+
+        return TestResolver;
+      }
+
+      @Resolver(() => TestResponse)
+      class TestResolver extends makeResolverClass() {
+        @FieldResolver(() => Boolean, { nullable: false })
+        public async exampleFieldResolver(): Promise<boolean> {
+          return true;
+        }
+      }
+
+      @ObjectType()
+      class OtherTestResponse {
+        @Field()
+        data!: string;
+      }
+
+      @ArgsType()
+      class OtherTestArgs {
+        @Field(() => Int, { defaultValue: 0 })
+        testField!: number;
+      }
+
+      function makeOtherResolverClass() {
+        @Resolver(() => OtherTestResponse)
+        abstract class OtherTestResolver {
+          @Query(() => OtherTestResponse)
+          async exampleQuery(@Args() args: OtherTestArgs): Promise<OtherTestResponse> {
+            return {
+              data: `resolver ${args.testField}`,
+            };
+          }
+        }
+
+        return OtherTestResolver;
+      }
+
+      @Resolver(() => OtherTestResponse)
+      class OtherTestResolver extends makeOtherResolverClass() {
+        @FieldResolver(() => Boolean, { nullable: false })
+        public async exampleFieldResolver(): Promise<boolean> {
+          return true;
+        }
+      }
+
+      const fistSchemaInfo = await getSchemaInfo({
+        resolvers: [TestResolver],
+      });
+
+      const hasFoundFieldResolverInSchema = fistSchemaInfo.schemaIntrospection.types.some(
+        type =>
+          type.kind === "OBJECT" &&
+          type.name === "TestResponse" &&
+          type.fields?.some(field => field.name === "exampleFieldResolver"),
+      );
+      expect(hasFoundFieldResolverInSchema).toBeTruthy();
+
+      const secondSchemaInfo = await getSchemaInfo({
+        resolvers: [OtherTestResolver],
+      });
+
+      const hasFoundFieldResolverInOtherSchema = secondSchemaInfo.schemaIntrospection.types.some(
+        type =>
+          type.kind === "OBJECT" &&
+          type.name === "OtherTestResponse" &&
+          type.fields?.some(field => field.name === "exampleFieldResolver"),
+      );
+      expect(hasFoundFieldResolverInOtherSchema).toBeTruthy();
+    });
   });
 });


### PR DESCRIPTION
This PR is another approach (after #1691 by community) to fix an issue related to subsequent schema builds, especially when we have resolvers with inheritance and those resolvers queries/mutations contains args.

The approach to fix this was to just block subsequent metadata storage `.build()` actions, which were mutating the initial metadata storage values.

Fixes #1321 🚀 