### PR TITLE
docs: fix pubSub.publish code example

### DIFF
--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -147,7 +147,7 @@ import { pubSub } from "./pubsub";
 class SampleResolver {
   // ...
   @Mutation(returns => Boolean)
-  async addNewComment(@Arg("comment") input: CommentInput, @PubSub() pubSub: PubSubEngine) {
+  async addNewComment(@Arg("comment") input: CommentInput) {
     const comment = this.commentsService.createNew(input);
     await this.commentsRepository.save(comment);
     // Trigger subscriptions topics


### PR DESCRIPTION
Typegraphql doesn't provide PubSub decorator. it provide only an interface. The code example should call pubSub instance created before to publish a notification.