### PR TITLE
perf(schema): remove O(N²) field-resolver lookup in buildTypesInfo

### DIFF
--- a/src/schema/schema-generator.ts
+++ b/src/schema/schema-generator.ts
@@ -33,6 +33,7 @@ import { convertTypeIfScalar, getEnumValuesMap, wrapWithTypeOptions } from "@/he
 import {
   type ClassMetadata,
   type FieldMetadata,
+  type FieldResolverMetadata,
   type ParamMetadata,
   type ResolverMetadata,
   type SubscriptionResolverMetadata,
@@ -202,6 +203,39 @@ export abstract class SchemaGenerator {
   }
 
   private static buildTypesInfo(resolvers: Function[]) {
+    // Perf: the field-resolver lookups in the object-type and interface-type
+    // `fields` thunks below used to re-filter/re-scan `metadataStorage.fieldResolvers`
+    // once per field per type — O(fields × fieldResolvers), i.e. quadratic in schema
+    // size. Prebuild `target -> (schemaName -> metadata)` indexes here (once) so each
+    // per-field lookup is O(1). `Array#find` returns the first match, so the index keeps
+    // the first-seen entry for a given (target, schemaName) to preserve semantics exactly.
+    const buildFieldResolverIndex = (list: FieldResolverMetadata[]) => {
+      const index = new Map<Function, Map<string, FieldResolverMetadata>>();
+      for (const fieldResolver of list) {
+        const objectTypeTarget = fieldResolver.getObjectType!();
+        let byName = index.get(objectTypeTarget);
+        if (!byName) {
+          byName = new Map<string, FieldResolverMetadata>();
+          index.set(objectTypeTarget, byName);
+        }
+        if (!byName.has(fieldResolver.schemaName)) {
+          byName.set(fieldResolver.schemaName, fieldResolver);
+        }
+      }
+      return index;
+    };
+    // Object types only consider internal field resolvers plus those on the selected
+    // resolver classes (matches the original `.filter(...)` predicate); interface types
+    // consider all field resolvers (matches the original unfiltered `.find(...)`).
+    const objectFieldResolverIndex = buildFieldResolverIndex(
+      this.metadataStorage.fieldResolvers.filter(
+        it => it.kind === "internal" || resolvers.includes(it.target),
+      ),
+    );
+    const interfaceFieldResolverIndex = buildFieldResolverIndex(
+      this.metadataStorage.fieldResolvers,
+    );
+
     this.unionTypesInfoMap = new Map<symbol, UnionTypeInfo>(
       this.metadataStorage.unions.map(unionMetadata => {
         // use closure to capture values from this selected schema build
@@ -333,14 +367,9 @@ export abstract class SchemaGenerator {
 
               let fields = fieldsMetadata.reduce<GraphQLFieldConfigMap<any, any>>(
                 (fieldsMap, field) => {
-                  const { fieldResolvers } = this.metadataStorage;
-                  const filteredFieldResolversMetadata = fieldResolvers.filter(
-                    it => it.kind === "internal" || resolvers.includes(it.target),
-                  );
-                  const fieldResolverMetadata = filteredFieldResolversMetadata.find(
-                    it =>
-                      it.getObjectType!() === field.target && it.schemaName === field.schemaName,
-                  );
+                  const fieldResolverMetadata = objectFieldResolverIndex
+                    .get(field.target)
+                    ?.get(field.schemaName);
                   const type = this.getGraphQLOutputType(
                     field.target,
                     field.name,
@@ -454,11 +483,9 @@ export abstract class SchemaGenerator {
 
               let fields = fieldsMetadata!.reduce<GraphQLFieldConfigMap<any, any>>(
                 (fieldsMap, field) => {
-                  const fieldResolverMetadata = this.metadataStorage.fieldResolvers.find(
-                    resolver =>
-                      resolver.getObjectType!() === field.target &&
-                      resolver.schemaName === field.schemaName,
-                  );
+                  const fieldResolverMetadata = interfaceFieldResolverIndex
+                    .get(field.target)
+                    ?.get(field.schemaName);
                   const type = this.getGraphQLOutputType(
                     field.target,
                     field.name,


### PR DESCRIPTION
## Problem

`SchemaGenerator.buildTypesInfo` resolves each field's advanced field-resolver metadata by scanning the global `metadataStorage.fieldResolvers` array **once per field, per object/interface type**:

```ts
// object-type `fields` thunk — inside the per-field reduce:
const { fieldResolvers } = this.metadataStorage;
const filteredFieldResolversMetadata = fieldResolvers.filter(   // loop-invariant, recomputed every field!
  it => it.kind === "internal" || resolvers.includes(it.target),
);
const fieldResolverMetadata = filteredFieldResolversMetadata.find(
  it => it.getObjectType!() === field.target && it.schemaName === field.schemaName,
);
```

That is **O(fields × fieldResolvers)** — quadratic in schema size. For the object-type thunk the loop-invariant `.filter(...)` is *also* recomputed inside the per-field `reduce`, compounding the cost. The interface-type thunk has the same per-field `.find()` scan.

On large schemas this makes `buildSchema` / `buildSchemaSync` super-linear. In our production app (~1,380 object types generated from a metadata-driven ORM) this single hotspot was the dominant boot cost — `buildSchemaSync` measured **66.3s**, dropping to **1.2s** after this change (~54×). The win grows with schema size because the removed cost is quadratic; it's a one-time build cost and does not affect per-request resolution.

## Fix

Prebuild two `target -> (schemaName -> metadata)` indexes **once** at the top of `buildTypesInfo`, turning each per-field lookup into an O(1) `Map` access:

- `objectFieldResolverIndex` — built from the **filtered** list (`kind === "internal" || resolvers.includes(target)`), matching the object-type thunk's original predicate.
- `interfaceFieldResolverIndex` — built from the **full** `fieldResolvers` list, matching the interface-type thunk's original unfiltered `.find(...)`.

The index keeps the **first-seen** entry for a given `(target, schemaName)`, preserving `Array#find` first-match semantics exactly.

## Correctness / risk

Pure `filter`/`find` → hash-index memoization. The grouping keys are exactly the join keys of the original predicates, and first-match order is preserved, so the generated schema is byte-for-byte identical.

- ✅ Full functional suite passes unchanged: **30 suites / 488 tests / 26 snapshots** (`jest tests/functional`).
- ✅ `tsc --noEmit` clean for both `tsconfig.esm.json` and `tsconfig.cjs.json`.
- ✅ Prettier + ESLint clean on the changed file.

No public API change; no new dependency.